### PR TITLE
Hotfix/markdown

### DIFF
--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -7,12 +7,15 @@ const GlobalStyles = createGlobalStyle`
     * {
       font-family: Pretendard, sans-serif;
       box-sizing: border-box;
-      list-style-type: none;
       text-decoration: none;
       border-collapse: collapse;
     }
   }
   
+  ul, ol {
+    list-style-type: none;
+  }
+
   a {
     text-decoration: none;
     color: inherit;
@@ -24,7 +27,7 @@ const GlobalStyles = createGlobalStyle`
     padding: 0;
   }
 
-   @font-face {
+  @font-face {
     font-family: 'Jalnan';
     src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_four@1.2/JalnanOTF00.woff")
       format("woff");

--- a/src/components/solve/ProblemDescription/ProblemDescription.tsx
+++ b/src/components/solve/ProblemDescription/ProblemDescription.tsx
@@ -4,7 +4,7 @@ import Modal from "../../Modal/Modal";
 import { HorizontalLine, TestCase, Text } from "./common";
 import TestCaseModal from "./TestCaseModal";
 import { useCallback, useMemo, useState } from "react";
-import MarkDownRenderer from "../../../lib/MarkdownRenderer";
+import MarkdownRenderer from "../../../lib/MarkdownRenderer";
 
 interface ProblemDescriptionProps {
   problemNumber: number;
@@ -60,9 +60,10 @@ export default function ProblemDescription({
         />
       </Modal>
       <ProblemTitle>문제 {problemNumber}</ProblemTitle>
-      <StyledMarkdownText>
-        <MarkDownRenderer markdownString={problemMarkdown} />
-      </StyledMarkdownText>
+      <MarkdownRenderer
+        markdownString={problemMarkdown}
+        StyledWrapper={MarkdownStyledWrapper}
+      />
       <HorizontalLine margin="25px 0 14px 0" />
       {/**
       // TODO: 문제설명 마크다운에 디자인 추가
@@ -185,9 +186,8 @@ const AddTestCaseButton = styled.button`
   }
 `;
 
-const StyledMarkdownText = styled(Text)`
+const MarkdownStyledWrapper = styled.div`
   h1 {
-    font-weight: 700;
     font-size: 40px;
     line-height: 160%;
   }
@@ -203,22 +203,7 @@ const StyledMarkdownText = styled(Text)`
   }
   p {
     font-size: 18px;
-  }
-  em {
-    font-style: italic !important;
-  }
-  strong {
-    font-weight: bold;
-  }
-  ul {
-    li {
-      list-style: inside disc;
-    }
-  }
-  ol {
-    li {
-      list-style: inside decimal;
-    }
+    line-height: 160%;
   }
   code {
     background: rgba(135, 131, 120, 0.15);

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -124,4 +124,16 @@ const PreventGlobalStylesResetWrapper = styled.div`
   code {
     font-family: monospace;
   }
+
+  blockquote {
+    display: block;
+    margin: 0;
+    margin-top: 0;
+    margin-bottom: 16px;
+    padding: 0 1em;
+    border-left: 0.25em solid #d0d7de;
+    > p {
+      color: #656d76;
+    }
+  }
 `;

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -1,17 +1,127 @@
 import { ReactMarkdown } from "react-markdown/lib/react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
+import { IStyledComponent, styled } from "styled-components";
 
-type MarkDownRendererProps = {
+type MarkdownRendererProps = {
   markdownString: string;
+  StyledWrapper?: IStyledComponent<"web", "div">;
 };
 
-export default function MarkDownRenderer({
+export default function MarkdownRenderer({
   markdownString,
-}: MarkDownRendererProps) {
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
-      {markdownString}
-    </ReactMarkdown>
-  );
+  StyledWrapper,
+}: MarkdownRendererProps) {
+  if (StyledWrapper)
+    return (
+      <PreventGlobalStylesResetWrapper>
+        <StyledWrapper>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+          >
+            {markdownString}
+          </ReactMarkdown>
+        </StyledWrapper>
+      </PreventGlobalStylesResetWrapper>
+    );
+  else
+    return (
+      <PreventGlobalStylesResetWrapper>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+          {markdownString}
+        </ReactMarkdown>
+      </PreventGlobalStylesResetWrapper>
+    );
 }
+
+// 그냥 user agent stylesheet 박아넣는 styled Component
+const PreventGlobalStylesResetWrapper = styled.div`
+  h1 {
+    display: block;
+    font-size: 2em;
+    margin-block-start: 0.67em;
+    margin-block-end: 0.67em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  h2 {
+    display: block;
+    font-size: 1.5em;
+    margin-block-start: 0.83em;
+    margin-block-end: 0.83em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  h3 {
+    display: block;
+    font-size: 1.17em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  h4 {
+    display: block;
+    margin-block-start: 1.33em;
+    margin-block-end: 1.33em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  h5 {
+    display: block;
+    font-size: 0.83em;
+    margin-block-start: 1.67em;
+    margin-block-end: 1.67em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  h6 {
+    display: block;
+    font-size: 0.67em;
+    margin-block-start: 2.33em;
+    margin-block-end: 2.33em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+  }
+  p {
+    display: block;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+  }
+  em {
+    font-style: italic;
+  }
+  strong {
+    font-weight: bold;
+  }
+  ul {
+    display: block;
+    list-style: inside disc; // 공식 default는 outside이긴 하다.
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+  }
+  ol {
+    display: block;
+    list-style: inside decimal; // 공식 default는 outside이긴 하다.
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    padding-inline-start: 40px;
+  }
+  code {
+    font-family: monospace;
+  }
+`;

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -122,7 +122,7 @@ const PreventGlobalStylesResetWrapper = styled.div`
     padding-inline-start: 40px;
   }
   code {
-    font-family: monospace;
+    /* font-family: monospace; */
   }
 
   blockquote {

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -6,7 +6,7 @@ import openedListItemIcon from "/icon/announcement/OpenedListItem.svg";
 import { TAnnouncement } from "../types/apiTypes";
 import { useQuery } from "react-query";
 import { getAllAnnouncements } from "../apis/announcement";
-import MarkDownRenderer from "../lib/MarkdownRenderer";
+import MarkdownRenderer from "../lib/MarkdownRenderer";
 import { Union } from "../types/commonTypes";
 
 const listItemStates = [
@@ -93,7 +93,10 @@ function ListItem({
       <p>
         {title}
         {listItemState === "isSelected" && (
-          <MarkDownRenderer markdownString={content} />
+          <MarkdownRenderer
+            markdownString={content}
+            StyledWrapper={MarkdownStyledWrapper}
+          />
         )}
       </p>
       <p>{(updated_at || created_at).slice(0, 10).split("-").join(".")}</p>
@@ -181,13 +184,6 @@ const ListItemRow = styled(ListRow)`
     font-weight: 500;
     ${({ listItemState }) =>
       listItemState === "isSelected" && { "font-weight": "600" }}
-    > p {
-      margin-top: 46px;
-      font-size: 18px;
-      font-weight: normal;
-      line-height: 185%;
-      color: #373737;
-    }
   }
   > div:nth-child(4) {
     padding: 0 38%;
@@ -205,5 +201,15 @@ const NoAnnouncements = styled.div`
     font-weight: 500;
     font-size: 20px;
     line-height: 140%;
+  }
+`;
+
+const MarkdownStyledWrapper = styled.div`
+  p {
+    margin-top: 46px;
+    font-size: 18px;
+    font-weight: normal;
+    line-height: 185%;
+    color: #373737;
   }
 `;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import Header from "../components/home/Header/Header";
 import { useLoaderData, useParams } from "react-router-dom";
 import { getRecruitingById } from "../apis/recruiting";
 import { QueryClient, useQuery } from "react-query";
-import MarkDownRenderer from "../lib/MarkdownRenderer";
+import MarkdownRenderer from "../lib/MarkdownRenderer";
 import { Recruiting } from "../types/apiTypes";
 
 const recruitingQuery = (id: number) => ({
@@ -43,15 +43,22 @@ export default function Dashboard() {
     <Main>
       <Header />
       <Title>
-        <MarkDownRenderer
+        <MarkdownRenderer
           markdownString={recruiting ? recruiting.name : "불러오는 중..."}
+          StyledWrapper={TitleMarkdownStyledWrapper}
         />
       </Title>
       <Description>
-        <MarkDownRenderer markdownString={markDownTexts.subTitle} />
+        <MarkdownRenderer
+          markdownString={markDownTexts.subTitle}
+          StyledWrapper={DescriptionMarkdownStyledWrapper}
+        />
       </Description>
       <Information>
-        <MarkDownRenderer markdownString={recruiting?.description ?? ""} />
+        <MarkdownRenderer
+          markdownString={recruiting?.description ?? ""}
+          StyledWrapper={InformationMarkdownStyledWrapper}
+        />
       </Information>
       <AnnouncementButton>
         공지 및 변경사항 안내
@@ -93,32 +100,47 @@ const Main = styled.main`
 `;
 
 const Title = styled.h1`
-  color: #222;
-  font-size: 40px;
-  font-weight: 600;
   margin: 9px 0;
 `;
 
+const TitleMarkdownStyledWrapper = styled.div`
+  p {
+    color: #222;
+    font-size: 40px;
+    font-weight: 600;
+  }
+`;
+
 const Description = styled.p`
-  color: #373737;
-  font-size: 20px;
-  font-weight: 500;
-  line-height: 160%; /* 32px */
-  letter-spacing: 0.8px;
   margin: 0;
   margin-bottom: 37px;
 `;
 
+const DescriptionMarkdownStyledWrapper = styled.div`
+  p {
+    color: #373737;
+    font-size: 20px;
+    font-weight: 500;
+    line-height: 160%; /* 32px */
+    letter-spacing: 0.8px;
+  }
+`;
+
 const Information = styled.div`
-  color: #737373;
-  font-size: 18px;
-  font-weight: 400;
-  line-height: 170%; /* 30.6px */
-  letter-spacing: 0.72px;
   margin-bottom: 34px;
-  span {
-    color: #b44f3d;
-    font-weight: 600;
+`;
+
+const InformationMarkdownStyledWrapper = styled.div`
+  p {
+    color: #737373;
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 170%; /* 30.6px */
+    letter-spacing: 0.72px;
+    span {
+      color: #b44f3d;
+      font-weight: 600;
+    }
   }
 `;
 

--- a/src/pages/Rookie.tsx
+++ b/src/pages/Rookie.tsx
@@ -4,7 +4,7 @@ import Header from "../components/home/Header/Header";
 import { useParams } from "react-router-dom";
 import { useQuery } from "react-query";
 import { getRecruitingById } from "../apis/recruiting";
-import MarkDownRenderer from "../lib/MarkdownRenderer";
+import MarkdownRenderer from "../lib/MarkdownRenderer";
 
 /**
  * ! Deprecated
@@ -29,13 +29,13 @@ export default function Rookie() {
     <Main>
       <Header />
       <Title>
-        <MarkDownRenderer markdownString={markDownTexts.title} />
+        <MarkdownRenderer markdownString={markDownTexts.title} />
       </Title>
       <Description>
-        <MarkDownRenderer markdownString={markDownTexts.subTitle} />
+        <MarkdownRenderer markdownString={markDownTexts.subTitle} />
       </Description>
       <Information>
-        <MarkDownRenderer markdownString={markDownTexts.information} />
+        <MarkdownRenderer markdownString={markDownTexts.information} />
       </Information>
       <AnnouncementButton>
         공지 및 변경사항 안내


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 --> 리뷰 필요

### 태스크 URL
https://github.com/wafflestudio/wacruit-web/pull/18#issuecomment-1660074862
### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [x] pre-commit 성공
- [x] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
- `MarkdownRenderer` 컴포넌트를 개선

### 테스트 방법 (Optional)

### 기타 질문 및 공유 사항 (Optional)
- Pretendard 폰트는 italic이 없다고 하네요.
- `ReactMarkdown`을 `user agent stylesheet`의 style들을 담은 `PreventGlobalStylesResetWrapper`로 감싸주어 `GlobalStyles`에 의한 초기화에 대응한다.
```html
<PreventGlobalStylesResetWrapper> // 그냥 user agent stylesheet 박아넣는 styled Component
  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
    {markdownString}
  </ReactMarkdown>
</PreventGlobalStylesResetWrapper>
```
- 선택적으로 마크다운에 적용할 styled-component `StyledWrapper`를 param으로 받을 수 있다.
- 이 경우 아래와 같은 순서로 감싸주어 style을 적용시켜준다.
```html
<PreventGlobalStylesResetWrapper>
  <StyledWrapper>
    <ReactMarkdown
      remarkPlugins={[remarkGfm]}
      rehypePlugins={[rehypeRaw]}
    >
      {markdownString}
    </ReactMarkdown>
  </StyledWrapper>
</PreventGlobalStylesResetWrapper>
```

`MarkdownRenderer` 사용 시 아래 예시와 같이 margin, padding 등을 설정하는 `container styled-component`와 마크다운 스타일을 설정하는 `styled wrapper styled-component`를 나누어 만드는 방법을 추천. 

```html
<Title>
  <MarkdownRenderer
    markdownString={recruiting ? recruiting.name : "불러오는 중..."}
    StyledWrapper={TitleMarkdownStyledWrapper}
  />
</Title>

const Title = styled.h1` // container styled-component
  margin: 9px 0;
`;

const TitleMarkdownStyledWrapper = styled.div` // styled wrapper styled-component
  p {
    color: #222;
    font-size: 40px;
    font-weight: 600;
  }
`;
```


