### PR TITLE
Feat/solve api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ]
   },
   "dependencies": {
+    "@codemirror/lang-cpp": "^6.0.2",
     "@codemirror/lang-java": "^6.0.1",
     "@codemirror/lang-javascript": "^6.1.9",
     "@codemirror/lang-python": "^6.1.3",

--- a/src/apis/problem.ts
+++ b/src/apis/problem.ts
@@ -1,5 +1,22 @@
-import { Problem } from "../types/apiTypes";
-import { getRequest } from "./utility";
+import {
+  Problem,
+  ProblemSubmissionRequest,
+  ProblemSubmissionResult,
+} from "../types/apiTypes";
+import { getRequest, sseRequest } from "./utility";
 
 export const getProblemById = (problem_id: number) =>
   getRequest<Problem>(`/problems/${problem_id}`);
+
+export const postProblemSubmission = (
+  problemSubmission: ProblemSubmissionRequest,
+) =>
+  sseRequest<
+    | { type: "skip"; data: { items: [] } }
+    | { type: "message"; data: { items: ProblemSubmissionResult[] } }
+  >(
+    "/problems/submission",
+    problemSubmission,
+    {}, // headers
+    true, // authorized
+  );

--- a/src/components/solve/CodeEditor/EditorToggle.tsx
+++ b/src/components/solve/CodeEditor/EditorToggle.tsx
@@ -8,7 +8,7 @@ interface Props {
 export default function EditorToggle(props: Props) {
   return (
     <Wrapper onClick={() => props.onChange(!props.value)}>
-      <span>Editor</span>
+      <span>Code Assistant</span>
       <Slot>
         <OnText value={props.value}>on</OnText>
         <OffText value={props.value}>off</OffText>
@@ -46,8 +46,8 @@ const Slot = styled.div`
 const TRANS_TIME = "0.2s";
 
 const Circle = styled.div<{ value: boolean }>`
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
 
   position: absolute;
   top: 2px;

--- a/src/components/solve/CodeEditor/LanguageSelection.tsx
+++ b/src/components/solve/CodeEditor/LanguageSelection.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
-
-const options = ["Python", "Java", "Javascript"] as const;
-export type Language = (typeof options)[number];
+import { Language, languages } from "./useLanguage.tsx";
 
 interface Props {
   language: Language;
@@ -19,7 +17,7 @@ export default function LanguageSelection(props: Props) {
       </ListToggleButton>
       {isOpen && (
         <List>
-          {options.map((option) => (
+          {languages.map((option) => (
             <li>
               <ListItemButton
                 $selected={props.language === option}

--- a/src/components/solve/CodeEditor/LanguageSelection.tsx
+++ b/src/components/solve/CodeEditor/LanguageSelection.tsx
@@ -46,6 +46,7 @@ const Wrapper = styled.div`
 const Button = styled.button`
   width: 100%;
   height: 35px;
+  padding: 0 5px;
 
   cursor: pointer;
   font-weight: 600;

--- a/src/components/solve/CodeEditor/index.tsx
+++ b/src/components/solve/CodeEditor/index.tsx
@@ -1,32 +1,32 @@
-import { java } from "@codemirror/lang-java";
-import { javascript } from "@codemirror/lang-javascript";
-import { python } from "@codemirror/lang-python";
-import { LanguageSupport } from "@codemirror/language";
 import { useCodeMirror } from "@uiw/react-codemirror";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 import EditorToggle from "./EditorToggle.tsx";
-import LanguageSelection, { Language } from "./LanguageSelection.tsx";
+import LanguageSelection from "./LanguageSelection.tsx";
+import { Language, languageSupports } from "./useLanguage.tsx";
 
 interface Props {
   isFullScreen: boolean;
   setIsFullScreen: (isFullScreen: boolean) => void;
+  code: string;
+  setCode: (code: string) => void;
+  language: Language;
+  setLanguage: (language: Language) => void;
 }
 
-const languages: Record<Language, LanguageSupport> = {
-  Python: python(),
-  Java: java(),
-  Javascript: javascript(),
-};
-
-export default function CodeEditor({ isFullScreen, setIsFullScreen }: Props) {
-  const [language, setLanguage] = useLanguage();
+export default function CodeEditor({
+  isFullScreen,
+  setIsFullScreen,
+  code,
+  setCode,
+  setLanguage,
+  language,
+}: Props) {
   const [isEditorOpen, setIsEditorOpen] = useState(true);
-  const [code, setCode] = useCode(language);
   const { setContainer } = useCodeMirror({
     height: "100%",
     style: { height: "100%" },
-    extensions: [languages[language]],
+    extensions: [languageSupports[language]],
     value: code,
     onChange: (v) => setCode(v),
   });
@@ -48,52 +48,6 @@ export default function CodeEditor({ isFullScreen, setIsFullScreen }: Props) {
       <EditorToggle value={isEditorOpen} onChange={(v) => setIsEditorOpen(v)} />
     </Section>
   );
-}
-
-/* 사용자의 패닉을 막기 위해 코드와 사용하던 언어는 새로고침하거나 재접속해도 그대로 유지됨 */
-
-// 문자열이면 그대로, 아니면 빈 문자열을 반환
-function safeString(_s: unknown) {
-  return typeof _s === "string" ? _s : "";
-}
-
-// localStorage에 저장된 코드를 React state로 캐시
-function useCode(language: Language) {
-  const [codes, setCodes] = useState<Partial<Record<Language, string>>>({});
-  const code = codes[language];
-  const setCode = useCallback(
-    (code: string) => {
-      setCodes((codes) => ({ ...codes, [language]: code }));
-      localStorage.setItem(`code-${language}`, code);
-    },
-    [language],
-  );
-  if (code === undefined) {
-    setCodes({
-      [language]: safeString(localStorage.getItem(`code-${language}`)),
-      ...codes,
-    });
-  }
-  return [code, setCode] as const;
-}
-
-// localStorage에 저장된 언어를 불러옴
-function getStoredLanguage() {
-  const storedLanguage = localStorage.getItem("language") ?? "";
-  if (storedLanguage in languages) {
-    return storedLanguage as Language;
-  }
-  return "Python";
-}
-
-// localStorage에 저장된 언어를 React state로 캐시
-function useLanguage() {
-  const [language, setLanguage] = useState<Language>(getStoredLanguage);
-  const _setLanguage = useCallback((language: Language) => {
-    setLanguage(language);
-    localStorage.setItem("language", language);
-  }, []);
-  return [language, _setLanguage] as const;
 }
 
 const Section = styled.section`

--- a/src/components/solve/CodeEditor/index.tsx
+++ b/src/components/solve/CodeEditor/index.tsx
@@ -94,6 +94,10 @@ const EditorWrapper = styled.div`
 
   grid-row: 2;
   grid-column: 1 / 5;
+
+  .cm-editor * {
+    font-family: monospace;
+  }
 `;
 
 const FullscreenButton = styled.button<{ $isFullScreen: boolean }>`

--- a/src/components/solve/CodeEditor/useCode.tsx
+++ b/src/components/solve/CodeEditor/useCode.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useState } from "react";
+import { Language } from "./useLanguage.tsx";
+
+/* 사용자의 패닉을 막기 위해 코드와 사용하던 언어는 새로고침하거나 재접속해도 그대로 유지됨 */
+
+// localStorage에 저장된 코드를 React state로 캐시
+export function useCode(language: Language) {
+  const [codes, setCodes] = useState<Partial<Record<Language, string>>>({});
+  const code = codes[language];
+  const setCode = useCallback(
+    (code: string) => {
+      setCodes((codes) => ({ ...codes, [language]: code }));
+      localStorage.setItem(`code-${language}`, code);
+    },
+    [language],
+  );
+  if (code === undefined) {
+    setCodes({
+      [language]: safeString(localStorage.getItem(`code-${language}`)),
+      ...codes,
+    });
+  }
+  return [code, setCode] as const;
+}
+
+// 문자열이면 그대로, 아니면 빈 문자열을 반환
+function safeString(_s: unknown) {
+  return typeof _s === "string" ? _s : "";
+}

--- a/src/components/solve/CodeEditor/useLanguage.tsx
+++ b/src/components/solve/CodeEditor/useLanguage.tsx
@@ -1,0 +1,38 @@
+import { python } from "@codemirror/lang-python";
+import { cpp } from "@codemirror/lang-cpp";
+import { javascript } from "@codemirror/lang-javascript";
+import { useCallback, useState } from "react";
+import { LanguageSupport } from "@codemirror/language";
+
+export const languages = ["Python", "C++", "Javascript"] as const;
+export type Language = (typeof languages)[number];
+export const languageSupports: Record<Language, LanguageSupport> = {
+  Python: python(),
+  "C++": cpp(),
+  Javascript: javascript(),
+};
+
+export const languageCodes: Record<Language, number> = {
+  "C++": 101,
+  Javascript: 103,
+  Python: 104,
+};
+
+// localStorage에 저장된 언어를 불러옴
+function getStoredLanguage() {
+  const storedLanguage = localStorage.getItem("language") ?? "";
+  if (storedLanguage in languageSupports) {
+    return storedLanguage as Language;
+  }
+  return "Python";
+}
+
+// localStorage에 저장된 언어를 React state로 캐시
+export function useLanguage() {
+  const [language, setLanguage] = useState<Language>(getStoredLanguage);
+  const _setLanguage = useCallback((language: Language) => {
+    setLanguage(language);
+    localStorage.setItem("language", language);
+  }, []);
+  return [language, _setLanguage] as const;
+}

--- a/src/components/solve/ProblemDescription/ProblemDescription.tsx
+++ b/src/components/solve/ProblemDescription/ProblemDescription.tsx
@@ -3,28 +3,26 @@ import useModal from "../../Modal/useModal";
 import Modal from "../../Modal/Modal";
 import { HorizontalLine, TestCase, Text } from "./common";
 import TestCaseModal from "./TestCaseModal";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback } from "react";
 import MarkDownRenderer from "../../../lib/MarkdownRenderer";
 
 interface ProblemDescriptionProps {
   problemNumber: number;
   problemMarkdown: string;
+  defaultTestCases: TestCase[];
+  customTestCases: TestCase[];
+  setCustomTestCases: (
+    param: TestCase[] | ((prev: TestCase[]) => TestCase[]),
+  ) => void;
 }
 
 export default function ProblemDescription({
   problemNumber,
   problemMarkdown,
+  defaultTestCases,
+  customTestCases,
+  setCustomTestCases,
 }: ProblemDescriptionProps) {
-  const defaultTestCases: TestCase[] = [
-    { input: "4, 5", output: "a=4\nb=5" },
-    { input: "4, 5", output: "a=4\nb=5" },
-    { input: "4, 5", output: "a=4\nb=5" },
-  ];
-  const CUSTOM_TEST_CASES_KEY = `customTestCasesOfProblemNumber${problemNumber}`;
-  const [customTestCases, setCustomTestCases] = useCustomTestCases(
-    CUSTOM_TEST_CASES_KEY,
-  );
-
   const deleteCustomTestCase = useCallback(
     (deleteIdx: number) =>
       setCustomTestCases((prev) => prev.filter((_, idx) => deleteIdx !== idx)),
@@ -92,27 +90,6 @@ export default function ProblemDescription({
 
 /* code start: 커스텀 테스트 케이스도 localStorage에 저장하며 사용한다 */
 
-function useCustomTestCases(customTestCasesKey: string) {
-  const storedCustomTestCases: TestCase[] = useMemo(
-    () => JSON.parse(localStorage.getItem(customTestCasesKey) || "[]"),
-    [customTestCasesKey],
-  );
-
-  const [customTestCases, setCustomTestCases] = useState<TestCase[]>(
-    storedCustomTestCases,
-  );
-
-  const setCustomTestCasesWithLocalStorage = useCallback(
-    (param: TestCase[] | ((prev: TestCase[]) => TestCase[])) => {
-      const newTestCases: TestCase[] =
-        typeof param === "function" ? param(customTestCases) : param;
-      setCustomTestCases(newTestCases);
-      localStorage.setItem(customTestCasesKey, JSON.stringify(newTestCases));
-    },
-    [customTestCases, customTestCasesKey],
-  );
-  return [customTestCases, setCustomTestCasesWithLocalStorage] as const;
-}
 /* end */
 
 const Section = styled.section`

--- a/src/components/solve/ProblemDescription/useCustomTestCases.tsx
+++ b/src/components/solve/ProblemDescription/useCustomTestCases.tsx
@@ -1,0 +1,25 @@
+import { TestCase } from "./common.tsx";
+import { useCallback, useMemo, useState } from "react";
+
+export function useCustomTestCases(problemNumber: number) {
+  const customTestCasesKey = `customTestCasesOfProblemNumber${problemNumber}`;
+  const storedCustomTestCases: TestCase[] = useMemo(
+    () => JSON.parse(localStorage.getItem(customTestCasesKey) || "[]"),
+    [customTestCasesKey],
+  );
+
+  const [customTestCases, setCustomTestCases] = useState<TestCase[]>(
+    storedCustomTestCases,
+  );
+
+  const setCustomTestCasesWithLocalStorage = useCallback(
+    (param: TestCase[] | ((prev: TestCase[]) => TestCase[])) => {
+      const newTestCases: TestCase[] =
+        typeof param === "function" ? param(customTestCases) : param;
+      setCustomTestCases(newTestCases);
+      localStorage.setItem(customTestCasesKey, JSON.stringify(newTestCases));
+    },
+    [customTestCases, customTestCasesKey],
+  );
+  return [customTestCases, setCustomTestCasesWithLocalStorage] as const;
+}

--- a/src/components/solve/TestResultConsole.tsx
+++ b/src/components/solve/TestResultConsole.tsx
@@ -26,7 +26,7 @@ export default function TestResultConsole(props: Props) {
 const Section = styled.section`
   border: 4px solid #373737;
   border-top-width: 2px;
-  border-radius: 0 0 5px 5px;
+  border-radius: 5px;
 
   /* Solve page layout */
   flex: 1;

--- a/src/components/solve/TestResultConsole.tsx
+++ b/src/components/solve/TestResultConsole.tsx
@@ -1,10 +1,24 @@
 import styled from "styled-components";
+import { ProblemSubmissionResult } from "../../types/apiTypes.ts";
 
-export default function TestResultConsole() {
+type Props = {
+  results: ProblemSubmissionResult[];
+};
+
+export default function TestResultConsole(props: Props) {
   return (
     <Section>
       <h3>Console</h3>
-      <pre>{"Hello, world\nProcess finished with exit code 0"}</pre>
+      <ul>
+        {props.results.map((result) => (
+          <li key={result.num}>
+            <div>{result.num}번 테스트케이스</div>
+            <div>시간: {result.time}초</div>
+            <div>메모리: {result.memory}KB</div>
+            <div>결과: {result.status.description}</div>
+          </li>
+        ))}
+      </ul>
     </Section>
   );
 }

--- a/src/lib/unreachable.ts
+++ b/src/lib/unreachable.ts
@@ -1,0 +1,3 @@
+export function unreachable(x: never) {
+  throw new Error("Unexpected object: " + x);
+}

--- a/src/mocks/handler/problemHandler.ts
+++ b/src/mocks/handler/problemHandler.ts
@@ -18,7 +18,7 @@ const submitProblem: RestHandler = rest.post(
     const requestBody = (await req.json()) as ProblemSubmissionRequest;
     const id = req.params.problem_id;
     const problem = getMockProblem(Number(id));
-    const extraTestcases = requestBody.extra_testcases;
+    const extraTestcases = requestBody.extra_testcases ?? [];
     if (problem === undefined) return res(ctx.status(404));
     const result = [...problem.testcases, ...extraTestcases].map((testcase) => {
       const correct = Math.random() > 0.5;

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -57,16 +57,20 @@ export default function Solve() {
             expected_output: t.output,
           })),
     });
-    for await (const { data, type } of res) {
-      switch (type) {
-        case "skip":
-          break;
-        case "message":
-          setTestResults((prev) => [...prev, ...data.items]);
-          break;
-        default:
-          unreachable(type);
+    try {
+      for await (const { data, type } of res) {
+        switch (type) {
+          case "skip":
+            break;
+          case "message":
+            setTestResults((prev) => [...prev, ...data.items]);
+            break;
+          default:
+            unreachable(type);
+        }
       }
+    } catch (e) {
+      alert("알 수 없는 오류가 발생했습니다");
     }
     setIsSubmitting(false);
   };

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -87,7 +87,7 @@ export default function Solve() {
     <Container>
       <Main>
         <TopNav>
-          <Link to={"/"}>
+          <Link to={`/recruiting/${params.recruit_id}`}>
             <img src="/icon/LeftArrow.svg" alt="&larr;" width={31} />
             Back
           </Link>

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -1,6 +1,3 @@
-import { Union } from "./commonTypes";
-import { supportedLanguages } from "./constants";
-
 /**
  * User
  */
@@ -58,7 +55,7 @@ export type RecruitingSummary = Pick<
  * Problem
  */
 
-export type TestCase = {
+export type ApiTestCase = {
   stdin: string;
   expected_output: string;
 };
@@ -66,28 +63,26 @@ export type TestCase = {
 export type Problem = {
   num: number;
   body: string;
-  testcases: TestCase[];
+  testcases: ApiTestCase[];
 };
 
 export type ProblemSubmissionRequest = {
   problem_id: number;
-  language: Union<typeof supportedLanguages>;
+  language: number;
   source_code: string;
-  is_test: boolean;
-  extra_testcases: TestCase[];
+  is_example?: boolean;
+  extra_testcases?: ApiTestCase[];
 };
 
-export type ProblemSubmissionResponse = {
-  items: {
+export type ProblemSubmissionResult = {
+  num: number;
+  status: {
     id: number;
-    /**
-     * Todo: status type 확정되면 constant로 빼기
-     */
-    status: number;
-    stdout: string | null;
-    time: number;
-    memory: number;
-  }[];
+    description: string;
+  };
+  stdout: string | null;
+  time: number;
+  memory: number;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,14 @@
     "@codemirror/view" "^6.0.0"
     "@lezer/common" "^1.0.0"
 
+"@codemirror/lang-cpp@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-cpp/-/lang-cpp-6.0.2.tgz#076c98340c3beabde016d7d83e08eebe17254ef9"
+  integrity sha512-6oYEYUKHvrnacXxWxYa6t4puTlbN3dgV662BDfSH8+MfjQjVmP697/KYTDOqpxgerkvoNm7q5wlFMBeX8ZMocg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/cpp" "^1.0.0"
+
 "@codemirror/lang-java@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@codemirror/lang-java/-/lang-java-6.0.1.tgz#03bd06334da7c8feb9dff6db01ac6d85bd2e48bb"
@@ -1413,6 +1421,14 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.3.tgz#1808f70e2b0a7b1fdcbaf5c074723d2d4ed1e4c5"
   integrity sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==
+
+"@lezer/cpp@^1.0.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lezer/cpp/-/cpp-1.1.1.tgz#ac0261f48dc3651bfea13fdaeff35f04c9011a7f"
+  integrity sha512-eS1M3L3U2mDowoFVPG7tEp01SWu9/68Nx3HEBgLJVn3N9ku7g5S7WdFv0jzmcTipAyONYfZJ+7x4WRkfdB2Ung==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
 
 "@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
   version "1.1.6"


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: 리뷰 필요

### 태스크 URL
https://www.notion.so/wafflestudio/SSE-45d876355bb64ef0bc2e25b475469ca2?pvs=4

### 체크리스트
__PR 전__
- [x] 칸반 생성
- [x] pre-commit 성공
- [ ] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
- 코드 제출 API 연결 -- EventSource API를 사용하면 처음에 POST 데이터를 보낼 수 없기 때문에 fetch로 SSE 구현
- 기타 solve 페이지 스타일 수정

### 테스트 방법 (Optional)
- .env에 로그인 토큰을 설정하고, 아무 문제 페이지나 들어가서 제출해본다.
- 제출이 되는 문제가 있고 안 되는 문제가 있는듯한데, API 응답에 써있는대로 관리자에게 문의해보면 될 것 같습니다.

### 기타 질문 및 공유 사항 (Optional)
- 테스트케이스 보여주는 부분 comment out 해놨던데 일단 그대로 뒀습니다.
- 이젠 정말로 지원할 언어를 결정할 때입니다.
- 실행 결과를 보여주는 디자인도 필요합니다
- 코드 제출 결과와 관련된 구체적인 documentation이 있으면 좋겠습니다.
  - 이벤트 type은 skip과 message만 처리하면 될지?
  - 제출에 실패하는 경우는 어떨 때인지?