### PR TITLE
FIX : 대시보드 '아래 내용'=>'위 내용'

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -67,7 +67,7 @@ export default function Dashboard() {
           isDesigner={recruiting.id === 2}
         />
         <Caution>
-          아래 내용은 제출 후에도 상시 수정할 수 있으며, 모두 제출해야 지원
+          위 내용은 제출 후에도 상시 수정할 수 있으며, 모두 제출해야 지원
           완료됩니다.
           <CancelButton>지원 취소</CancelButton>
         </Caution>


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 -->

### 태스크 URL
https://wafflestudio.slack.com/archives/C01KGJSRPRC/p1691078909850469?thread_ts=1691059030.876299&cid=C01KGJSRPRC
### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [x] pre-commit 성공
- [x] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
대시보드 가장 아래 텍스트 '아래 내용'=>'위 내용' 수정했습니다. 