### PR TITLE
Feat/new announcement modal

### DIFF
--- a/src/components/home/Header/Header.tsx
+++ b/src/components/home/Header/Header.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { zIndex } from "../../../lib/zIndex";
 import { useQuery } from "@tanstack/react-query";
 import { checkAuth, deleteSsoToken, tryLogin } from "../../../apis/auth";
-import { getAllAnnouncements } from "../../../apis/announcement";
 import { useState } from "react";
 import { LoadingBackgroundBlink } from "../../../lib/loading";
 import { useQueryClient } from "@tanstack/react-query";
@@ -20,17 +19,6 @@ export default function Header() {
     queryKey: ["auth"],
     queryFn: () => checkAuth(),
     staleTime: 1000 * 60 * 60,
-    retry: 0,
-  });
-
-  /**
-   * Announcement Polling
-   */
-  useQuery({
-    queryKey: ["announcement"],
-    queryFn: () => getAllAnnouncements(),
-    refetchInterval: 1000 * 5,
-    staleTime: Infinity,
     retry: 0,
   });
 

--- a/src/components/home/NotificationModal.tsx
+++ b/src/components/home/NotificationModal.tsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { getAllAnnouncements } from "../../apis/announcement";
 
 type NotificationModalProps = {
   closeModal: () => void;
@@ -10,23 +12,21 @@ export default function NotificationModal({
   closeModal,
   setDontShowModalDate,
 }: NotificationModalProps) {
-  const notificationData = {
-    title: "지원 일자 변경 안내",
-    main: `웹사이트 상의 문제로 인해
-    8월 4일 (금) 정오부터 리크루팅을 시작하도록 하겠습니다. 
-    지원자 여러분들께 불편을 드려 죄송합니다.
-    `,
-  };
+  const { data: latestAnnouncement } = useQuery({
+    queryKey: ["announcement"],
+    queryFn: () => getAllAnnouncements().then((res) => res[0]),
+    staleTime: 1,
+  });
   return (
     <Article>
       <ContentsWapper>
         <ImageContainer>
           <img src="/icon/Notification.svg" alt="" />
         </ImageContainer>
-        <Title>{notificationData.title}</Title>
-        <MainText>{notificationData.main}</MainText>
-        {/* TODO : 주소 연결 */}
-        <Link to="./">자세히보기</Link>
+        <Title>{latestAnnouncement?.title}</Title>
+        <MainText>{latestAnnouncement?.content}</MainText>
+        {/* TODO : 오류 해결 */}
+        <Link to="/announcement/">자세히보기</Link>
       </ContentsWapper>
       <ButtonWrapper>
         <Button
@@ -48,7 +48,7 @@ const Article = styled.article`
   position: fixed;
   top: 124px;
   left: 164px;
-  max-width: 405px;
+  width: 405px;
   border-radius: 15px;
   background-color: #fff;
 `;

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -47,8 +47,9 @@ export default function Announcement() {
                 <p>등록된 공지사항이 없습니다.</p>
               </NoAnnouncements>
             ) : (
-              announcements.map((announcement) => (
+              announcements.map((announcement, idx) => (
                 <ListItem
+                  key={idx}
                   announcement={announcement}
                   listItemState={
                     selectedAnnouncementId === undefined
@@ -88,7 +89,7 @@ function ListItem({
   // TODO: 공지 여러 개 한꺼번에 확인 불가?
   const { id, title, content, updated_at, created_at } = announcement;
   return (
-    <ListItemRow onClick={handleOnClick} listItemState={listItemState}>
+    <ListItemRow onClick={handleOnClick} $listItemState={listItemState}>
       <p>{id + 1}</p>
       <p>
         {title}
@@ -142,7 +143,7 @@ const AnnouncementList = styled.ol`
   min-width: 970px;
 `;
 
-const ListRow = styled.li<{ listItemState?: ListItemState }>`
+const ListRow = styled.li<{ $listItemState?: ListItemState }>`
   display: grid;
   grid-template-columns: 9fr 68fr 17fr 7fr;
   font-size: 20px;
@@ -168,13 +169,13 @@ const ListHeaderRow = styled(ListRow)`
 const ListItemRow = styled(ListRow)`
   cursor: pointer;
   color: #3c3c3c;
-  ${({ listItemState }) =>
-    listItemState === "isSelected" && {
+  ${({ $listItemState }) =>
+    $listItemState === "isSelected" && {
       color: "#222222",
       "font-weight": "500",
     }}
-  ${({ listItemState }) =>
-    listItemState === "SomethingElseSelected" && { color: "#9c9c9c" }}
+  ${({ $listItemState }) =>
+    $listItemState === "SomethingElseSelected" && { color: "#9c9c9c" }}
   padding: 30px 0 32px 0;
 
   > p:first-child {
@@ -182,8 +183,8 @@ const ListItemRow = styled(ListRow)`
   }
   > p:nth-child(2) {
     font-weight: 500;
-    ${({ listItemState }) =>
-      listItemState === "isSelected" && { "font-weight": "600" }}
+    ${({ $listItemState }) =>
+      $listItemState === "isSelected" && { "font-weight": "600" }}
   }
   > div:nth-child(4) {
     padding: 0 38%;

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -18,7 +18,7 @@ type ListItemState = Union<typeof listItemStates>;
 
 export default function Announcement() {
   const { data: announcements } = useQuery({
-    queryKey: ["announcement"],
+    queryKey: ["announcement", "all"],
     queryFn: () => getAllAnnouncements(),
     staleTime: 1,
   });

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -90,7 +90,7 @@ function ListItem({
   const { id, title, content, updated_at, created_at } = announcement;
   return (
     <ListItemRow onClick={handleOnClick} $listItemState={listItemState}>
-      <p>{id + 1}</p>
+      <p>{id}</p>
       <p>
         {title}
         {listItemState === "isSelected" && (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,7 +19,7 @@ const LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID = "latestAnnouncementId";
 export default function Home() {
   const modalHandle = useModal(0);
   const { data: latestAnnouncement } = useQuery({
-    queryKey: ["announcement"],
+    queryKey: ["announcement", "latest"],
     queryFn: () => getAllAnnouncements().then((res) => res[0]),
     refetchInterval: 1000 * 60,
     staleTime: Infinity,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,22 +10,38 @@ import Modal from "../components/Modal/Modal";
 import NotificationModal from "../components/home/NotificationModal";
 import { useEffect } from "react";
 import Header from "../components/home/Header/Header";
+import { getAllAnnouncements } from "../apis/announcement";
+import { useQuery } from "react-query";
 
 const LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE = "dontShowExpireDate";
+// const LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID = "latestAnnouncementId";
 
 export default function Home() {
   const modalHandle = useModal(0);
+  // const ANNOUNCEMENT_ID = Number(
+  //   localStorage.getItem(LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID),
+  // );
   const DONT_SHOW_MODAL_DATE = Number(
     localStorage.getItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE),
   );
 
+  const { data: announcements } = useQuery({
+    queryKey: ["announcement"],
+    queryFn: () => getAllAnnouncements(),
+    refetchInterval: 1000 * 5,
+    staleTime: Infinity,
+    retry: 0,
+  });
+  const latestAnnouncement = announcements ? announcements[0] : undefined;
+
   useEffect(() => {
-    if (!DONT_SHOW_MODAL_DATE) {
-      modalHandle.openModal();
-    } else if (new Date().getDate() !== DONT_SHOW_MODAL_DATE) {
-      modalHandle.openModal();
-      localStorage.setItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE, "");
-    }
+    if (latestAnnouncement?.id)
+      if (!DONT_SHOW_MODAL_DATE) {
+        modalHandle.openModal();
+      } else if (new Date().getDate() !== DONT_SHOW_MODAL_DATE) {
+        modalHandle.openModal();
+        localStorage.setItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE, "");
+      }
   }, []);
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,38 +11,46 @@ import NotificationModal from "../components/home/NotificationModal";
 import { useEffect } from "react";
 import Header from "../components/home/Header/Header";
 import { getAllAnnouncements } from "../apis/announcement";
-import { useQuery } from "react-query";
+import { useQuery } from "@tanstack/react-query";
 
 const LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE = "dontShowExpireDate";
-// const LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID = "latestAnnouncementId";
+const LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID = "latestAnnouncementId";
 
 export default function Home() {
   const modalHandle = useModal(0);
-  // const ANNOUNCEMENT_ID = Number(
-  //   localStorage.getItem(LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID),
-  // );
-  const DONT_SHOW_MODAL_DATE = Number(
-    localStorage.getItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE),
-  );
-
-  const { data: announcements } = useQuery({
+  const { data: latestAnnouncement } = useQuery({
     queryKey: ["announcement"],
-    queryFn: () => getAllAnnouncements(),
+    queryFn: () => getAllAnnouncements().then((res) => res[0]),
     refetchInterval: 1000 * 5,
     staleTime: Infinity,
     retry: 0,
   });
-  const latestAnnouncement = announcements ? announcements[0] : undefined;
 
   useEffect(() => {
-    if (latestAnnouncement?.id)
-      if (!DONT_SHOW_MODAL_DATE) {
-        modalHandle.openModal();
-      } else if (new Date().getDate() !== DONT_SHOW_MODAL_DATE) {
-        modalHandle.openModal();
-        localStorage.setItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE, "");
-      }
-  }, []);
+    const LATEST_ANNOUNCEMENT_ID = Number(
+      localStorage.getItem(LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID),
+    );
+    if (
+      latestAnnouncement &&
+      latestAnnouncement.id !== LATEST_ANNOUNCEMENT_ID
+    ) {
+      localStorage.setItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE, "");
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY_LATEST_ANNOUNCEMENT_ID,
+        latestAnnouncement.id.toString(),
+      );
+    }
+
+    const DONT_SHOW_MODAL_DATE = Number(
+      localStorage.getItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE),
+    );
+    if (!DONT_SHOW_MODAL_DATE) {
+      modalHandle.openModal();
+    } else if (new Date().getDate() !== DONT_SHOW_MODAL_DATE) {
+      modalHandle.openModal();
+      localStorage.setItem(LOCAL_STORAGE_KEY_DONT_SHOW_MODAL_DATE, "");
+    }
+  }, [latestAnnouncement]);
 
   return (
     <>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -21,7 +21,7 @@ export default function Home() {
   const { data: latestAnnouncement } = useQuery({
     queryKey: ["announcement"],
     queryFn: () => getAllAnnouncements().then((res) => res[0]),
-    refetchInterval: 1000 * 5,
+    refetchInterval: 1000 * 60,
     staleTime: Infinity,
     retry: 0,
   });


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 --> 리뷰 필요

### 태스크 URL

### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [x] pre-commit 성공
- [x] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
가장 최근 공지를 공지모달로 띄우는 작업 완료했습니다. 다만 오류가 있는데 해결 방법을 모르겠네요..

### 기타 질문 및 공유 사항 (Optional)
- 공지모달의 자세히보기를 클릭하여 `/announcement`로 이동하면 아래와 같은 화면이 뜹니다. 근데 새로고침하면 정상적으로 작동해요. 빠른 해결이 어려우면 일단 `자세히 보기` 버튼 부분 주석 처리해야할 것 같습니다 죄송합니다ㅜ 
![image](https://github.com/wafflestudio/wacruit-web/assets/105846051/1b5b480f-be36-4d2e-9b3a-52d44d010783)

- 비슷하게 `announcement`에서 헤더의 로고를 클릭해서 `Home`으로 이동하면 아래와 같은 오류 발생합니다.. 마찬가지로 새로고침하면 정상적으로 작동합니다.
![image](https://github.com/wafflestudio/wacruit-web/assets/105846051/72711175-175a-4578-b30e-dcde5bee5dd5)

