### PR TITLE
Update: 코드를 유사 ref에 저장; rerender 횟수를 줄임

### DIFF
--- a/src/components/solve/CodeEditor/useCode.tsx
+++ b/src/components/solve/CodeEditor/useCode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { boilerplates, Language } from "./useLanguage.tsx";
 
 /* 사용자의 패닉을 막기 위해 코드와 사용하던 언어는 새로고침하거나 재접속해도 그대로 유지됨 */
@@ -24,6 +24,31 @@ export function useCode(language: Language, problemNumber: number) {
     });
   }
   return [code, setCode] as const;
+}
+
+export function useCodeRef(language: Language, problemNumber: number) {
+  const codes = useRef<Partial<Record<Language, string>>>({});
+  return useMemo(
+    () => ({
+      get current() {
+        return (
+          codes.current[language] ??
+          safeString(
+            localStorage.getItem(`code-lang:${language}-no:${problemNumber}`),
+            boilerplates[language],
+          )
+        );
+      },
+      set current(newCode: string) {
+        codes.current[language] = newCode;
+        localStorage.setItem(
+          `code-lang:${language}-no:${problemNumber}`,
+          newCode,
+        );
+      },
+    }),
+    [language, problemNumber],
+  );
 }
 
 // 문자열이면 그대로, 아니면 빈 문자열을 반환

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -12,7 +12,7 @@ import {
   languageCodes,
   useLanguage,
 } from "../components/solve/CodeEditor/useLanguage.tsx";
-import { useCode } from "../components/solve/CodeEditor/useCode.tsx";
+import { useCodeRef } from "../components/solve/CodeEditor/useCode.tsx";
 import { useCustomTestCases } from "../components/solve/ProblemDescription/useCustomTestCases.tsx";
 import { ProblemSubmissionResult } from "../types/apiTypes.ts";
 import { unreachable } from "../lib/unreachable.ts";
@@ -34,7 +34,8 @@ export default function Solve() {
   });
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [language, setLanguage] = useLanguage();
-  const [code, setCode] = useCode(language, problemNumber);
+  // const [code, setCode] = useCode(language, problemNumber);
+  const codeRef = useCodeRef(language, problemNumber);
   const [customTestcases, setCustomTestcases] =
     useCustomTestCases(problemNumber);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -43,7 +44,7 @@ export default function Solve() {
   const testConsoleRef = useRef<HTMLUListElement>(null);
 
   const handleSubmit = async (is_example: boolean) => {
-    if (!code) {
+    if (!codeRef.current) {
       alert("코드를 입력해주세요");
       return;
     }
@@ -54,7 +55,7 @@ export default function Solve() {
     const res = postProblemSubmission({
       problem_id: problemNumber,
       language: languageCodes[language],
-      source_code: code,
+      source_code: codeRef.current,
       is_example,
       extra_testcases: is_example
         ? customTestcases.map((t) => ({
@@ -138,8 +139,10 @@ export default function Solve() {
               <CodeEditor
                 isFullScreen={isFullScreen}
                 setIsFullScreen={setIsFullScreen}
-                code={code ?? ""}
-                setCode={setCode}
+                code={codeRef.current}
+                setCode={(newCode) => {
+                  codeRef.current = newCode;
+                }}
                 language={language}
                 setLanguage={setLanguage}
               />
@@ -168,7 +171,7 @@ export default function Solve() {
               <SubmitButton
                 onClick={() => {
                   if (!confirm("정말로 코드를 초기화하시겠습니까?")) return;
-                  setCode(boilerplates[language]);
+                  codeRef.current = boilerplates[language];
                 }}
               >
                 코드 초기화


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 -->

### 태스크 URL

### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [ ] pre-commit 성공
- [ ] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
- 사파리에서 코드 에디터의 성능이 눈에 띄게 떨어지는 것을 발견, code를 ref로 전환.
  - 현재는 codeRef의 내용이 이벤트 콜백과 codemirror에서만 사용되기 때문에 크게 문제가 없음. 이후 코드 수정할 때 주의