### PR TITLE
FIX : progressCard & resumeCard 화살표 중앙정렬 조정

### DIFF
--- a/src/components/rookie/Progress/ProgressCard.tsx
+++ b/src/components/rookie/Progress/ProgressCard.tsx
@@ -109,7 +109,7 @@ const Button = styled.button`
   position: absolute;
   width: 30px;
   height: 30px;
-  padding: 2.5px;
+  padding: 2px 0 0 0;
   border-radius: 50%;
   border: 1px solid #737373;
   right: 27px;

--- a/src/components/rookie/Progress/ResumeCard.tsx
+++ b/src/components/rookie/Progress/ResumeCard.tsx
@@ -68,7 +68,7 @@ const Button = styled.button`
   position: absolute;
   width: 30px;
   height: 30px;
-  padding: 2.5px;
+  padding: 2px 0 0 0;
   border-radius: 50%;
   border: 1px solid #737373;
   right: 27px;


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 -->

### 태스크 URL

### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [x] pre-commit 성공
- [x] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
![image](https://github.com/wafflestudio/wacruit-web/assets/105846051/3f170631-aac2-4b0f-b29b-e43315fc942a)
각 카드 화살표 이미지 중앙정렬해두었습니다.
