### PR TITLE
hotfix: url 삭제 시 위에서부터 채우게

### DIFF
--- a/src/components/rookie/Progress/PortfolioCard.tsx
+++ b/src/components/rookie/Progress/PortfolioCard.tsx
@@ -46,7 +46,7 @@ export default function PortfolioCard() {
   useEffect(() => {
     if (links) {
       const updated = linksInput.map((input, index) =>
-        links.items[index] ? links.items[index] : input,
+        links.items[index] ? links.items[index] : { id: null, url: "" },
       );
       setLinksInput(updated);
     }


### PR DESCRIPTION
### 요약
- 마감 기한: YY-MM-DD
- 상태: <!-- 상태: 시작 안 함 / 진행 중 / 리뷰 필요 / 머지 필요 -->

### 태스크 URL

### 체크리스트
__PR 전__
- [ ] 칸반 생성
- [x] pre-commit 성공
- [x] type-label 추가

__머지 전__
- [ ] 칸반 옮기기
- [ ] 코멘트 리졸브
- [ ] squash & merge

### 작업 목록
url 삭제 시 남은 값을 위에서부터 채우는 핫픽스

### 테스트 방법 (Optional)
url 입력 두 칸을 모두 채운 후, 위 칸의 내용을 삭제하면 됩니다(자동으로 아래 칸의 내용이 위로 올라갑니다)

### 기타 질문 및 공유 사항 (Optional)
