### PR TITLE
Refact/layout ratio

### DIFF
--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -4,7 +4,7 @@ import reset from "styled-reset";
 const GlobalStyles = createGlobalStyle`
   ${reset}
   html {
-    font-size: 10px;
+    font-size: 9px;
   }
 
   body {

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -3,6 +3,10 @@ import reset from "styled-reset";
 
 const GlobalStyles = createGlobalStyle`
   ${reset}
+  html {
+    font-size: 10px;
+  }
+
   body {
     * {
       font-family: Pretendard, sans-serif;

--- a/src/components/home/Activity.tsx
+++ b/src/components/home/Activity.tsx
@@ -48,7 +48,7 @@ const Section = styled.section`
   position: relative;
   width: 100%;
   background: #f6f6f6;
-  padding: 100px 0px;
+  padding: 10rem 0rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -56,13 +56,13 @@ const Section = styled.section`
 `;
 
 const ActivityCardArea = styled.div`
-  max-width: 980px;
+  max-width: 98rem;
   width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 32px;
+  gap: 3.2rem;
 `;
 
 function Card({ title, description }: CardProps) {
@@ -83,16 +83,16 @@ function Card({ title, description }: CardProps) {
 }
 
 const ActivityCard = styled.div<{ $hover: boolean }>`
-  padding: 30px 34px;
+  padding: 3rem 3.4rem;
   width: 100%;
-  border-radius: 29px;
-  border: 1px solid #bd8379;
+  border-radius: 2.9rem;
+  border: 0.1rem solid #bd8379;
 
   background-color: ${(props) => (props.$hover ? "#F0745F" : "#fff")};
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  gap: 30px;
+  gap: 3rem;
   align-items: center;
   h1 {
     color: ${(props) => (props.$hover ? "#ffffff" : "#F0745F")};
@@ -109,17 +109,17 @@ const CardTitle = styled.h1`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
 
-  font-size: 26px;
+  font-size: 2.6rem;
   font-weight: 600;
-  letter-spacing: -1.3px;
+  letter-spacing: -0.13rem;
 `;
 
 const CardDescription = styled.div`
   flex: 1 1 0;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 500;
-  line-height: 160%; /* 28.8px */
-  letter-spacing: 0.72px;
+  line-height: 160%; /* 2.88rem */
+  letter-spacing: 0.072rem;
 `;

--- a/src/components/home/Apply.tsx
+++ b/src/components/home/Apply.tsx
@@ -112,7 +112,7 @@ export default function Apply() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  padding: 100px 0;
+  padding: 10rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -131,7 +131,7 @@ const BackGround = styled.div`
 
 const ApplyCalender = styled.div`
   width: 100%;
-  max-width: 1300px;
+  max-width: 130rem;
   display: flex;
   flex-direction: column;
 `;
@@ -143,20 +143,20 @@ const SelectField = styled.div`
 `;
 
 const Select = styled.div<{ $active: boolean }>`
-  padding: 30px 0px;
+  padding: 3rem 0rem;
   flex: 1;
-  border-radius: 15px 15px 0px 0px;
+  border-radius: 1.5rem 1.5rem 0rem 0rem;
   text-align: center;
   font-family: Jalnan;
-  font-size: 22px;
+  font-size: 2.2rem;
   font-weight: 700;
-  letter-spacing: 0.66px;
+  letter-spacing: 0.066rem;
 
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  gap: 8px;
+  gap: 0.8rem;
 
   cursor: pointer;
 
@@ -170,8 +170,8 @@ const CalenderArea = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding: 0px 150px 70px;
-  border-radius: 0px 0px 20px 20px;
+  padding: 0rem 15rem 7rem;
+  border-radius: 0rem 0rem 2rem 2rem;
   background: #fff7e5;
   justify-content: start;
   align-items: center;
@@ -182,15 +182,15 @@ const DayWeek = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  padding: 56px 10px 38px;
+  padding: 5.6rem 1rem 3.8rem;
 
   p {
     color: #756643;
     font-family: "Fredoka One";
-    font-size: 30px;
+    font-size: 3rem;
     font-weight: 600;
-    line-height: 170%; /* 51px */
-    letter-spacing: 1.2px;
+    line-height: 170%; /* 5.1rem */
+    letter-spacing: 0.12rem;
   }
 
   p:nth-child(1) {
@@ -201,57 +201,57 @@ const DayWeek = styled.div`
 const ApplyButton = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 17px;
+  gap: 1.7rem;
   align-items: center;
 
   p {
     color: #434343;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 600;
     span {
       color: #f0745f;
       font-family: Jalnan;
-      font-size: 24px;
+      font-size: 2.4rem;
       font-weight: 700;
     }
   }
 
   button {
-    height: 70px;
-    width: 396px;
+    height: 7rem;
+    width: 39.6rem;
 
     border: none;
-    border-radius: 20px;
+    border-radius: 2rem;
     background: #f0745f;
 
     color: #fff;
     font-family: Jalnan;
-    font-size: 22px;
+    font-size: 2.2rem;
     font-weight: 700;
-    letter-spacing: 0.88px;
+    letter-spacing: 0.088rem;
 
     cursor: pointer;
   }
 `;
 
 const Share = styled.div`
-  margin-top: 126px;
+  margin-top: 12.6rem;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 3.2rem;
 `;
 
 const ShareText = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 1rem;
 
   h1 {
     color: #434343;
     text-align: center;
-    font-size: 30px;
+    font-size: 3rem;
     font-weight: 700;
-    line-height: 140%; /* 42px */
+    line-height: 140%; /* 4.2rem */
     span {
       color: #f0745f;
       font-family: Jalnan;
@@ -260,9 +260,9 @@ const ShareText = styled.div`
   p {
     color: #837c6d;
     text-align: center;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 500;
-    line-height: 140%; /* 25.2px */
+    line-height: 140%; /* 2.52rem */
   }
 `;
 
@@ -270,14 +270,14 @@ const ShareButton = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
-  gap: 42px;
+  gap: 4.2rem;
 `;
 const ShareIcon = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 68px;
-  height: 68px;
+  width: 6.8rem;
+  height: 6.8rem;
   border-radius: 50%;
   background: #f0745f;
   cursor: pointer;

--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -16,32 +16,32 @@ export default function Banner() {
       <ForeGround>
         <BannerText>
           <img
-            style={{ position: "absolute", right: "-70px", top: "-20px" }}
+            style={{ position: "absolute", right: "-7.0rem", top: "-2.0rem" }}
             src="/image/home/banner/ReadingGlass.svg"
             alt="Glass"
           />
           <img
-            style={{ position: "absolute", left: "48px", bottom: "100px" }}
+            style={{ position: "absolute", left: "4.8rem", bottom: "10.0rem" }}
             src="/image/home/banner/Eyes.svg"
             alt="Eyes"
           />
           <img
-            style={{ position: "absolute", left: "-150px", bottom: "60px" }}
+            style={{ position: "absolute", left: "-15.0rem", bottom: "6.0rem" }}
             src="/image/home/banner/MousePointer.svg"
             alt="Mouse"
           />
           <img
-            style={{ position: "absolute", left: "28px", bottom: "170px" }}
+            style={{ position: "absolute", left: "2.8rem", bottom: "17.0rem" }}
             src="/image/home/stars/Star20.svg"
             alt="Star"
           />
           <img
-            style={{ position: "absolute", left: "-8px", bottom: "185px" }}
+            style={{ position: "absolute", left: "-0.8rem", bottom: "18.5rem" }}
             src="/image/home/stars/Star30.svg"
             alt="Star"
           />
           <img
-            style={{ position: "absolute", right: "-70px", top: "-60px" }}
+            style={{ position: "absolute", right: "-7.0rem", top: "-6.0rem" }}
             src="/image/home/stars/Star40.svg"
             alt="Star"
           />
@@ -60,7 +60,7 @@ export default function Banner() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  height: 980px;
+  height: 98rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -74,7 +74,7 @@ const ForeGround = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 60px;
+  gap: 6rem;
 `;
 
 const BannerText = styled.div`
@@ -84,88 +84,92 @@ const BannerText = styled.div`
   h1 {
     color: #fff;
     font-family: Jalnan;
-    font-size: 64px;
+    font-size: 6.4rem;
     font-style: normal;
     font-weight: 700;
     line-height: normal;
     text-align: center;
-    text-shadow: calc(5px * 1) 0 0 #292929,
-      calc(5px * 0.9239) calc(5px * 0.3827) 0 #292929,
-      calc(5px * 0.7071) calc(5px * 0.7071) 0 #292929,
-      calc(5px * 0.3827) calc(5px * 0.9239) 0 #292929, 0 calc(5px * 1) 0 #292929,
-      calc(5px * -0.3827) calc(5px * 0.9239) 0 #292929,
-      calc(5px * -0.7071) calc(5px * 0.7071) 0 #292929,
-      calc(5px * -0.9239) calc(5px * 0.3827) 0 #292929,
-      calc(5px * -1) 0 0 #292929,
-      calc(5px * -0.9239) calc(5px * -0.3827) 0 #292929,
-      calc(5px * -0.7071) calc(5px * -0.7071) 0 #292929,
-      calc(5px * -0.3827) calc(5px * -0.9239) 0 #292929,
-      0 calc(5px * -1) 0 #292929,
-      calc(5px * 0.3827) calc(5px * -0.9239) 0 #292929,
-      calc(5px * 0.7071) calc(5px * -0.7071) 0 #292929,
-      calc(5px * 0.9239) calc(5px * -0.3827) 0 #292929,
+    text-shadow: calc(0.5rem * 1) 0 0 #292929,
+      calc(0.5rem * 0.9239) calc(0.5rem * 0.3827) 0 #292929,
+      calc(0.5rem * 0.7071) calc(0.5rem * 0.7071) 0 #292929,
+      calc(0.5rem * 0.3827) calc(0.5rem * 0.9239) 0 #292929,
+      0 calc(0.5rem * 1) 0 #292929,
+      calc(0.5rem * -0.3827) calc(0.5rem * 0.9239) 0 #292929,
+      calc(0.5rem * -0.7071) calc(0.5rem * 0.7071) 0 #292929,
+      calc(0.5rem * -0.9239) calc(0.5rem * 0.3827) 0 #292929,
+      calc(0.5rem * -1) 0 0 #292929,
+      calc(0.5rem * -0.9239) calc(0.5rem * -0.3827) 0 #292929,
+      calc(0.5rem * -0.7071) calc(0.5rem * -0.7071) 0 #292929,
+      calc(0.5rem * -0.3827) calc(0.5rem * -0.9239) 0 #292929,
+      0 calc(0.5rem * -1) 0 #292929,
+      calc(0.5rem * 0.3827) calc(0.5rem * -0.9239) 0 #292929,
+      calc(0.5rem * 0.7071) calc(0.5rem * -0.7071) 0 #292929,
+      calc(0.5rem * 0.9239) calc(0.5rem * -0.3827) 0 #292929,
       //
-      calc(5px * 1 + 12px) -7px 0 #292929,
-      calc(5px * 0.9239 + 12px) calc(5px * 0.3827 - 7px) 0 #292929,
-      calc(5px * 0.7071 + 12px) calc(5px * 0.7071 - 7px) 0 #292929,
-      calc(5px * 0.3827 + 12px) calc(5px * 0.9239 - 7px) 0 #292929,
-      12px calc(5px * 1 - 7px) 0 #292929,
-      calc(5px * -0.3827 + 12px) calc(5px * 0.9239 - 7px) 0 #292929,
-      calc(5px * -0.7071 + 12px) calc(5px * 0.7071 - 7px) 0 #292929,
-      calc(5px * -0.9239 + 12px) calc(5px * 0.3827 - 7px) 0 #292929,
-      calc(5px * -1 + 12px) -7px 0 #292929,
-      calc(5px * -0.9239 + 12px) calc(5px * -0.3827 - 7px) 0 #292929,
-      calc(5px * -0.7071 + 12px) calc(5px * -0.7071 - 7px) 0 #292929,
-      calc(5px * -0.3827 + 12px) calc(5px * -0.9239 - 7px) 0 #292929,
-      12px calc(5px * -1 - 7px) 0 #292929,
-      calc(5px * 0.3827 + 12px) calc(5px * -0.9239 - 7px) 0 #292929,
-      calc(5px * 0.7071 + 12px) calc(5px * -0.7071 - 7px) 0 #292929,
-      calc(5px * 0.9239 + 12px) calc(5px * -0.3827 - 7px) 0 #292929;
+      calc(0.5rem * 1 + 1.2rem) -0.7rem 0 #292929,
+      calc(0.5rem * 0.9239 + 1.2rem) calc(0.5rem * 0.3827 - 0.7rem) 0 #292929,
+      calc(0.5rem * 0.7071 + 1.2rem) calc(0.5rem * 0.7071 - 0.7rem) 0 #292929,
+      calc(0.5rem * 0.3827 + 1.2rem) calc(0.5rem * 0.9239 - 0.7rem) 0 #292929,
+      1.2rem calc(0.5rem * 1 - 0.7rem) 0 #292929,
+      calc(0.5rem * -0.3827 + 1.2rem) calc(0.5rem * 0.9239 - 0.7rem) 0 #292929,
+      calc(0.5rem * -0.7071 + 1.2rem) calc(0.5rem * 0.7071 - 0.7rem) 0 #292929,
+      calc(0.5rem * -0.9239 + 1.2rem) calc(0.5rem * 0.3827 - 0.7rem) 0 #292929,
+      calc(0.5rem * -1 + 1.2rem) -0.7rem 0 #292929,
+      calc(0.5rem * -0.9239 + 1.2rem) calc(0.5rem * -0.3827 - 0.7rem) 0 #292929,
+      calc(0.5rem * -0.7071 + 1.2rem) calc(0.5rem * -0.7071 - 0.7rem) 0 #292929,
+      calc(0.5rem * -0.3827 + 1.2rem) calc(0.5rem * -0.9239 - 0.7rem) 0 #292929,
+      1.2rem calc(0.5rem * -1 - 0.7rem) 0 #292929,
+      calc(0.5rem * 0.3827 + 1.2rem) calc(0.5rem * -0.9239 - 0.7rem) 0 #292929,
+      calc(0.5rem * 0.7071 + 1.2rem) calc(0.5rem * -0.7071 - 0.7rem) 0 #292929,
+      calc(0.5rem * 0.9239 + 1.2rem) calc(0.5rem * -0.3827 - 0.7rem) 0 #292929;
 
     span {
       color: #f0745f;
       font-family: Jalnan;
-      font-size: 84px;
-      text-shadow: calc(5px * 1) 0 0 #671f13,
-        calc(5px * 0.9239) calc(5px * 0.3827) 0 #671f13,
-        calc(5px * 0.7071) calc(5px * 0.7071) 0 #671f13,
-        calc(5px * 0.3827) calc(5px * 0.9239) 0 #671f13,
-        0 calc(5px * 1) 0 #671f13,
-        calc(5px * -0.3827) calc(5px * 0.9239) 0 #671f13,
-        calc(5px * -0.7071) calc(5px * 0.7071) 0 #671f13,
-        calc(5px * -0.9239) calc(5px * 0.3827) 0 #671f13,
-        calc(5px * -1) 0 0 #671f13,
-        calc(5px * -0.9239) calc(5px * -0.3827) 0 #671f13,
-        calc(5px * -0.7071) calc(5px * -0.7071) 0 #671f13,
-        calc(5px * -0.3827) calc(5px * -0.9239) 0 #671f13,
-        0 calc(5px * -1) 0 #671f13,
-        calc(5px * 0.3827) calc(5px * -0.9239) 0 #671f13,
-        calc(5px * 0.7071) calc(5px * -0.7071) 0 #671f13,
-        calc(5px * 0.9239) calc(5px * -0.3827) 0 #671f13,
+      font-size: 8.4rem;
+      text-shadow: calc(0.5rem * 1) 0 0 #671f13,
+        calc(0.5rem * 0.9239) calc(0.5rem * 0.3827) 0 #671f13,
+        calc(0.5rem * 0.7071) calc(0.5rem * 0.7071) 0 #671f13,
+        calc(0.5rem * 0.3827) calc(0.5rem * 0.9239) 0 #671f13,
+        0 calc(0.5rem * 1) 0 #671f13,
+        calc(0.5rem * -0.3827) calc(0.5rem * 0.9239) 0 #671f13,
+        calc(0.5rem * -0.7071) calc(0.5rem * 0.7071) 0 #671f13,
+        calc(0.5rem * -0.9239) calc(0.5rem * 0.3827) 0 #671f13,
+        calc(0.5rem * -1) 0 0 #671f13,
+        calc(0.5rem * -0.9239) calc(0.5rem * -0.3827) 0 #671f13,
+        calc(0.5rem * -0.7071) calc(0.5rem * -0.7071) 0 #671f13,
+        calc(0.5rem * -0.3827) calc(0.5rem * -0.9239) 0 #671f13,
+        0 calc(0.5rem * -1) 0 #671f13,
+        calc(0.5rem * 0.3827) calc(0.5rem * -0.9239) 0 #671f13,
+        calc(0.5rem * 0.7071) calc(0.5rem * -0.7071) 0 #671f13,
+        calc(0.5rem * 0.9239) calc(0.5rem * -0.3827) 0 #671f13,
         //
-        calc(5px * 1 + 12px) -7px 0 #671f13,
-        calc(5px * 0.9239 + 12px) calc(5px * 0.3827 - 7px) 0 #671f13,
-        calc(5px * 0.7071 + 12px) calc(5px * 0.7071 - 7px) 0 #671f13,
-        calc(5px * 0.3827 + 12px) calc(5px * 0.9239 - 7px) 0 #671f13,
-        12px calc(5px * 1 - 7px) 0 #671f13,
-        calc(5px * -0.3827 + 12px) calc(5px * 0.9239 - 7px) 0 #671f13,
-        calc(5px * -0.7071 + 12px) calc(5px * 0.7071 - 7px) 0 #671f13,
-        calc(5px * -0.9239 + 12px) calc(5px * 0.3827 - 7px) 0 #671f13,
-        calc(5px * -1 + 12px) -7px 0 #671f13,
-        calc(5px * -0.9239 + 12px) calc(5px * -0.3827 - 7px) 0 #671f13,
-        calc(5px * -0.7071 + 12px) calc(5px * -0.7071 - 7px) 0 #671f13,
-        calc(5px * -0.3827 + 12px) calc(5px * -0.9239 - 7px) 0 #671f13,
-        12px calc(5px * -1 - 7px) 0 #671f13,
-        calc(5px * 0.3827 + 12px) calc(5px * -0.9239 - 7px) 0 #671f13,
-        calc(5px * 0.7071 + 12px) calc(5px * -0.7071 - 7px) 0 #671f13,
-        calc(5px * 0.9239 + 12px) calc(5px * -0.3827 - 7px) 0 #671f13;
+        calc(0.5rem * 1 + 1.2rem) -0.7rem 0 #671f13,
+        calc(0.5rem * 0.9239 + 1.2rem) calc(0.5rem * 0.3827 - 0.7rem) 0 #671f13,
+        calc(0.5rem * 0.7071 + 1.2rem) calc(0.5rem * 0.7071 - 0.7rem) 0 #671f13,
+        calc(0.5rem * 0.3827 + 1.2rem) calc(0.5rem * 0.9239 - 0.7rem) 0 #671f13,
+        1.2rem calc(0.5rem * 1 - 0.7rem) 0 #671f13,
+        calc(0.5rem * -0.3827 + 1.2rem) calc(0.5rem * 0.9239 - 0.7rem) 0 #671f13,
+        calc(0.5rem * -0.7071 + 1.2rem) calc(0.5rem * 0.7071 - 0.7rem) 0 #671f13,
+        calc(0.5rem * -0.9239 + 1.2rem) calc(0.5rem * 0.3827 - 0.7rem) 0 #671f13,
+        calc(0.5rem * -1 + 1.2rem) -0.7rem 0 #671f13,
+        calc(0.5rem * -0.9239 + 1.2rem) calc(0.5rem * -0.3827 - 0.7rem) 0
+          #671f13,
+        calc(0.5rem * -0.7071 + 1.2rem) calc(0.5rem * -0.7071 - 0.7rem) 0
+          #671f13,
+        calc(0.5rem * -0.3827 + 1.2rem) calc(0.5rem * -0.9239 - 0.7rem) 0
+          #671f13,
+        1.2rem calc(0.5rem * -1 - 0.7rem) 0 #671f13,
+        calc(0.5rem * 0.3827 + 1.2rem) calc(0.5rem * -0.9239 - 0.7rem) 0 #671f13,
+        calc(0.5rem * 0.7071 + 1.2rem) calc(0.5rem * -0.7071 - 0.7rem) 0 #671f13,
+        calc(0.5rem * 0.9239 + 1.2rem) calc(0.5rem * -0.3827 - 0.7rem) 0 #671f13;
     }
   }
 `;
 
 const FlipClockContainer = styled.div`
-  width: 860px;
-  height: 150px;
+  width: 86rem;
+  height: 15rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -173,124 +177,124 @@ const FlipClockContainer = styled.div`
 
 const waffle1_1 = keyframes`
   0% {
-    transform: scale(0.5) translate(300px, 300px) rotate(0);
+    transform: scale(0.5) translate(30.0rem, 30.0rem) rotate(0);
     opacity: 0;
   }
   100%{
-    transform: scale(0.75) translate(530px, 700px) rotate(30deg);
+    transform: scale(0.75) translate(53.0rem, 70.0rem) rotate(30deg);
   }
 `;
 
 const waffle1_2 = keyframes`
   0% {
-    transform: scale(0.75) translate(530px, 700px) rotate(30deg);
+    transform: scale(0.75) translate(53.0rem, 70.0rem) rotate(30deg);
   }
   100%{
-   transform: scale(0.9) translate(602px, 460px) rotate(63deg);
+   transform: scale(0.9) translate(60.2rem, 46.0rem) rotate(63deg);
   }
 `;
 
 const waffle2_1 = keyframes`
   0% {
-    transform: scale(0.5) translate(550px, 280px) rotate(-110deg);
+    transform: scale(0.5) translate(55.0rem, 28.0rem) rotate(-110deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.75) translate(630px, 700px) rotate(-100deg);
+    transform: scale(0.75) translate(63.0rem, 70.0rem) rotate(-100deg);
   }
 `;
 
 const waffle2_2 = keyframes`
   0% {
-    transform: scale(0.75) translate(630px, 700px) rotate(-100deg);
+    transform: scale(0.75) translate(63.0rem, 70.0rem) rotate(-100deg);
   }
   100%{
-   transform:  scale(0.9) translate(810px, 510px) rotate(-60deg);
+   transform:  scale(0.9) translate(81.0rem, 51.0rem) rotate(-60deg);
   }
 `;
 
 const waffle3_1 = keyframes`
   0% {
-    transform: scale(0.2) translate(200px, 500px) rotate(-80deg);
+    transform: scale(0.2) translate(20.0rem, 50.0rem) rotate(-80deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.6) translate(420px, 900px) rotate(-60deg);
+    transform: scale(0.6) translate(42.0rem, 90.0rem) rotate(-60deg);
   }
 `;
 
 const waffle3_2 = keyframes`
   0% {
-    transform: scale(0.6) translate(420px, 900px) rotate(-60deg);
+    transform: scale(0.6) translate(42.0rem, 90.0rem) rotate(-60deg);
   }
   100%{
-    transform: scale(0.75) translate(490px, 620px) rotate(-44.955deg);
+    transform: scale(0.75) translate(49.0rem, 62.0rem) rotate(-44.955deg);
   }
 `;
 
 const waffle4_1 = keyframes`
   0% {
-    transform: scale(0.2) translate(1000px, 00px) rotate(80deg);
+    transform: scale(0.2) translate(100.0rem, 0.0rem) rotate(80deg);
     opacity: 0;
   }
   20%{
-     transform: scale(0.2) translate(1000px, 00px) rotate(80deg);
+     transform: scale(0.2) translate(100.0rem, 0.0rem) rotate(80deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.5) translate(1360px, 340px) rotate(133.046deg);
+    transform: scale(0.5) translate(136.0rem, 34.0rem) rotate(133.046deg);
     opacity:1;
   }
 `;
 
 const waffle5_1 = keyframes`
   0% {
-    transform: scale(0.3) translate(-600px, 500px) rotate(200deg);
+    transform: scale(0.3) translate(-60.0rem, 50.0rem) rotate(200deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.5) translate(-820px, 1000px) rotate(185deg);
+    transform: scale(0.5) translate(-82.0rem, 100.0rem) rotate(185deg);
   }
 `;
 
 const waffle5_2 = keyframes`
   0% {
-    transform: scale(0.5) translate(-820px, 1000px) rotate(185deg);
+    transform: scale(0.5) translate(-82.0rem, 100.0rem) rotate(185deg);
   }
   100%{
-    transform: scale(0.7) translate(-1000px, 530px) rotate(145.744deg);
+    transform: scale(0.7) translate(-100.0rem, 53.0rem) rotate(145.744deg);
   }
 `;
 
 const waffle6_1 = keyframes`
   0% {
-    transform: scale(0.7) translate(-300px, 200px) rotate(80deg);
+    transform: scale(0.7) translate(-30.0rem, 20.0rem) rotate(80deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.9) translate(-600px, 500px) rotate(60deg);
+    transform: scale(0.9) translate(-60.0rem, 50.0rem) rotate(60deg);
   }
 `;
 const waffle6_2 = keyframes`
   0% {
-    transform: scale(0.9) translate(-600px, 500px) rotate(60deg);
+    transform: scale(0.9) translate(-60.0rem, 50.0rem) rotate(60deg);
   }
   100%{
-    transform: scale(1.05) translate(-825px, 355px) rotate(34.223deg);
+    transform: scale(1.05) translate(-82.5rem, 35.5rem) rotate(34.223deg);
   }
 `;
 
 const waffle7_1 = keyframes`
   0% {
-    transform: scale(0.3) translate(-500px, 200px) rotate(60deg);
+    transform: scale(0.3) translate(-50.0rem, 20.0rem) rotate(60deg);
     opacity: 0;
   }  
   20% {
-    transform: scale(0.3) translate(-500px, 200px) rotate(60deg);
+    transform: scale(0.3) translate(-50.0rem, 20.0rem) rotate(60deg);
     opacity: 0;
   }
   100%{
-    transform: scale(0.5) translate(-1000px, 555px) rotate(40.022deg);
+    transform: scale(0.5) translate(-100.0rem, 55.5rem) rotate(40.022deg);
   }
 `;
 const BackGround = styled.div`
@@ -307,42 +311,42 @@ const BackGround = styled.div`
 
   #waffle1 {
     position: absolute;
-    transform: scale(0.9) translate(602px, 460px) rotate(63deg);
+    transform: scale(0.9) translate(60.2rem, 46rem) rotate(63deg);
     animation: 0.8s ease-in ${waffle1_1},
       0.6s cubic-bezier(0.04, 0.17, 0.47, 0.99) 0.8s ${waffle1_2};
   }
   #waffle2 {
     position: absolute;
-    transform: scale(0.9) translate(810px, 510px) rotate(-60deg);
+    transform: scale(0.9) translate(81rem, 51rem) rotate(-60deg);
     animation: 0.8s ease-in ${waffle2_1},
       0.6s cubic-bezier(0.04, 0.17, 0.47, 0.99) 0.8s ${waffle2_2};
   }
   #waffle3 {
     position: absolute;
-    transform: scale(0.75) translate(490px, 620px) rotate(-44.955deg);
+    transform: scale(0.75) translate(49rem, 62rem) rotate(-44.955deg);
     animation: 0.8s ease-in ${waffle3_1},
       0.6s cubic-bezier(0.04, 0.17, 0.47, 0.99) 0.8s ${waffle3_2};
   }
   #waffle4 {
     position: absolute;
-    transform: scale(0.5) translate(1360px, 340px) rotate(133.046deg);
+    transform: scale(0.5) translate(136rem, 34rem) rotate(133.046deg);
     animation: 1.6s ease ${waffle4_1};
   }
   #waffle5 {
     position: absolute;
-    transform: scale(0.7) translate(-1000px, 530px) rotate(145.744deg);
+    transform: scale(0.7) translate(-100rem, 53rem) rotate(145.744deg);
     animation: 0.8s ease-in ${waffle5_1},
       0.6s cubic-bezier(0.04, 0.17, 0.47, 0.99) 0.8s ${waffle5_2};
   }
   #waffle6 {
     position: absolute;
-    transform: scale(1.05) translate(-825px, 355px) rotate(34.223deg);
+    transform: scale(1.05) translate(-82.5rem, 35.5rem) rotate(34.223deg);
     animation: 0.8s ease-in ${waffle6_1},
       0.6s cubic-bezier(0.04, 0.17, 0.47, 0.99) 0.8s ${waffle6_2};
   }
   #waffle7 {
     position: absolute;
-    transform: scale(0.5) translate(-1000px, 555px) rotate(40.022deg);
+    transform: scale(0.5) translate(-100rem, 55.5rem) rotate(40.022deg);
     animation: 1.6s ease ${waffle7_1};
   }
 `;

--- a/src/components/home/CalenderInner.tsx
+++ b/src/components/home/CalenderInner.tsx
@@ -10,21 +10,21 @@ export default function CalenderInner({ select }: CalenderInnerProps) {
       <ImageArea>
         {select === "ROOKIE" && (
           <img
-            style={{ width: "105px", height: "105px" }}
+            style={{ width: "10.5rem", height: "10.5rem" }}
             src={"/image/home/members/Rookie.svg"}
             alt="rookie img"
           />
         )}
         {select === "DESIGNER" && (
           <img
-            style={{ width: "105px", height: "105px" }}
+            style={{ width: "10.5rem", height: "10.5rem" }}
             src={"/image/home/members/Designer.svg"}
             alt="designer img"
           />
         )}
         {select === "PROGRAMMER" && (
           <img
-            style={{ width: "105px", height: "105px" }}
+            style={{ width: "10.5rem", height: "10.5rem" }}
             src={"/image/home/members/Programmer.svg"}
             alt="programmer img"
           />
@@ -236,47 +236,47 @@ export default function CalenderInner({ select }: CalenderInnerProps) {
 
 const Section = styled.section`
   width: 100%;
-  padding: 90px 0;
+  padding: 9rem 0;
   position: relative;
   display: flex;
   justify-content: center;
-  gap: 42px;
+  gap: 4.2rem;
 `;
 
 const ImageArea = styled.div`
-  width: 105px;
-  height: 105px;
+  width: 10.5rem;
+  height: 10.5rem;
 `;
 
 const TextArea = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 2.8rem;
 `;
 
 const InnerTop = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 2.8rem;
 `;
 
 const TopTitle = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 0.7rem;
 
   h1 {
     color: #c8604e;
-    font-size: 26px;
+    font-size: 2.6rem;
     font-weight: 800;
-    line-height: 160%; /* 41.6px */
+    line-height: 160%; /* 4.16rem */
   }
 
   p {
     color: #525252;
-    font-size: 20px;
+    font-size: 2rem;
     font-weight: 600;
-    line-height: 150%; /* 30px */
+    line-height: 150%; /* 3.0rem */
     span {
       color: #aa4533;
     }
@@ -287,9 +287,9 @@ const TopDescription = styled.ul`
   padding-left: 1em;
   li {
     color: #666259;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 400;
-    line-height: 185%; /* 33.3px */
+    line-height: 185%; /* 3.3299999999999996rem */
     list-style: disc outside;
     word-break: keep-all;
     span {
@@ -301,26 +301,26 @@ const TopDescription = styled.ul`
 const InnerBottom = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 4rem;
 
   h1 {
     color: #3b3b3b;
-    font-size: 20px;
+    font-size: 2rem;
     font-style: normal;
     font-weight: 600;
-    line-height: 180%; /* 36px */
+    line-height: 180%; /* 3.6rem */
   }
 `;
 
 const Step = styled.div`
   display: flex;
   flex-direction: row;
-  gap: 48px;
+  gap: 4.8rem;
 `;
 
 const StepImage = styled.div`
-  width: 75px;
-  height: 75px;
+  width: 7.5rem;
+  height: 7.5rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -331,20 +331,20 @@ const StepImage = styled.div`
 const StepDescription = styled.div`
   span {
     color: #f0745f;
-    font-size: 12px;
+    font-size: 1.2rem;
     font-weight: 500;
   }
 
   h1 {
     position: relative;
-    top: 3px;
+    top: 0.3rem;
   }
 
   p {
     color: #827a68;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 400;
-    line-height: 150%; /* 24px */
-    letter-spacing: 0.64px;
+    line-height: 150%; /* 2.4rem */
+    letter-spacing: 0.064rem;
   }
 `;

--- a/src/components/home/Countdown.tsx
+++ b/src/components/home/Countdown.tsx
@@ -7,9 +7,9 @@ export default function Countdown() {
       <FlipClockCountdown
         to={new Date("2023-08-13T23:59:59")}
         digitBlockStyle={{
-          width: "77px",
-          height: "121px",
-          fontSize: "74px",
+          width: "7.7rem",
+          height: "12.1rem",
+          fontSize: "7.4rem",
           boxShadow: "none",
         }}
         labels={["DAY", "HOUR", "MIN", "SEC"]}

--- a/src/components/home/Introduce.tsx
+++ b/src/components/home/Introduce.tsx
@@ -35,78 +35,78 @@ export default function Introduce() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  padding: 60px 0;
+  padding: 6rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   background: #f0745f;
-  gap: 50px;
+  gap: 5rem;
 `;
 
 const IntroduceTop = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 2.2rem;
   text-align: center;
   h1 {
     color: #fff;
     font-family: Jalnan;
-    font-size: 24px;
+    font-size: 2.4rem;
     font-weight: 700;
 
     span {
       color: #fff;
       font-family: Jalnan;
-      font-size: 32px;
-      -webkit-text-stroke: 2px #8b3c2e;
+      font-size: 3.2rem;
+      -webkit-text-stroke: 0.2rem #8b3c2e;
       font-weight: 700;
-      text-shadow: calc(0.5px * 1) 0 0 #8b3c2e,
-        calc(0.5px * 0.9239) calc(0.5px * 0.3827) 0 #8b3c2e,
-        calc(0.5px * 0.7071) calc(0.5px * 0.7071) 0 #8b3c2e,
-        calc(0.5px * 0.3827) calc(0.5px * 0.9239) 0 #8b3c2e,
-        0 calc(0.5px * 1) 0 #8b3c2e,
-        calc(0.5px * -0.3827) calc(0.5px * 0.9239) 0 #8b3c2e,
-        calc(0.5px * -0.7071) calc(0.5px * 0.7071) 0 #8b3c2e,
-        calc(0.5px * -0.9239) calc(0.5px * 0.3827) 0 #8b3c2e,
-        calc(0.5px * -1) 0 0 #8b3c2e,
-        calc(0.5px * -0.9239) calc(0.5px * -0.3827) 0 #8b3c2e,
-        calc(0.5px * -0.7071) calc(0.5px * -0.7071) 0 #8b3c2e,
-        calc(0.5px * -0.3827) calc(0.5px * -0.9239) 0 #8b3c2e,
-        0 calc(0.5px * -1) 0 #8b3c2e,
-        calc(0.5px * 0.3827) calc(0.5px * -0.9239) 0 #8b3c2e,
-        calc(0.5px * 0.7071) calc(0.5px * -0.7071) 0 #8b3c2e,
-        calc(0.5px * 0.9239) calc(0.5px * -0.3827) 0 #8b3c2e;
+      text-shadow: calc(0.05rem * 1) 0 0 #8b3c2e,
+        calc(0.05rem * 0.9239) calc(0.05rem * 0.3827) 0 #8b3c2e,
+        calc(0.05rem * 0.7071) calc(0.05rem * 0.7071) 0 #8b3c2e,
+        calc(0.05rem * 0.3827) calc(0.05rem * 0.9239) 0 #8b3c2e,
+        0 calc(0.05rem * 1) 0 #8b3c2e,
+        calc(0.05rem * -0.3827) calc(0.05rem * 0.9239) 0 #8b3c2e,
+        calc(0.05rem * -0.7071) calc(0.05rem * 0.7071) 0 #8b3c2e,
+        calc(0.05rem * -0.9239) calc(0.05rem * 0.3827) 0 #8b3c2e,
+        calc(0.05rem * -1) 0 0 #8b3c2e,
+        calc(0.05rem * -0.9239) calc(0.05rem * -0.3827) 0 #8b3c2e,
+        calc(0.05rem * -0.7071) calc(0.05rem * -0.7071) 0 #8b3c2e,
+        calc(0.05rem * -0.3827) calc(0.05rem * -0.9239) 0 #8b3c2e,
+        0 calc(0.05rem * -1) 0 #8b3c2e,
+        calc(0.05rem * 0.3827) calc(0.05rem * -0.9239) 0 #8b3c2e,
+        calc(0.05rem * 0.7071) calc(0.05rem * -0.7071) 0 #8b3c2e,
+        calc(0.05rem * 0.9239) calc(0.05rem * -0.3827) 0 #8b3c2e;
     }
   }
   p {
     color: #fff8f6;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 500;
     line-height: 160%;
-    letter-spacing: 0.64px;
+    letter-spacing: 0.064rem;
   }
 `;
 
 const IntroduceBottom = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 2.2rem;
 `;
 
 const BottomLine = styled.div`
   display: flex;
   align-items: flex-start;
-  gap: 20px;
+  gap: 2rem;
 
   & > div:nth-child(1) {
-    padding: 4px 15px;
-    border-radius: 11.5px;
-    border: 1px solid #8b3c2e;
+    padding: 0.4rem 1.5rem;
+    border-radius: 1.15rem;
+    border: 0.1rem solid #8b3c2e;
     background: #fff;
 
     color: #df6d59;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 600;
   }
 
@@ -115,14 +115,14 @@ const BottomLine = styled.div`
     flex-direction: column;
     justify-content: center;
     color: #fff;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 600;
     line-height: 180%;
 
     & > p {
       color: #fff6f6;
       font-family: Pretendard;
-      font-size: 16px;
+      font-size: 1.6rem;
       font-weight: 400;
       line-height: 180%;
     }
@@ -130,7 +130,7 @@ const BottomLine = styled.div`
 
   & > p {
     color: #fff6f6;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 400;
     line-height: 180%;
   }

--- a/src/components/home/Member.tsx
+++ b/src/components/home/Member.tsx
@@ -44,7 +44,7 @@ export default function Member() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  padding: 100px 0;
+  padding: 10rem 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -53,7 +53,7 @@ const Section = styled.section`
 
 const MemberCardArea = styled.div`
   width: 100%;
-  max-width: 1400px;
+  max-width: 140rem;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -87,19 +87,19 @@ const CardContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 1rem;
   background-color: #fff;
-  width: 280px;
-  /* width: 310px;
-  border-radius: 10px;
-  padding: 30px 15px;
-  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(0, 0, 0, 0.1); */
+  width: 28rem;
+  /* width: 31.0rem;
+  border-radius: 1.0rem;
+  padding: 3.0rem 1.5rem;
+  box-shadow: 0.0rem 0.0rem 1.0rem rgba(0, 0, 0, 0.1);
+  border: 0.1rem solid rgba(0, 0, 0, 0.1); */
 `;
 
 const ImageArea = styled.div`
-  width: 150px;
-  height: 150px;
+  width: 15rem;
+  height: 15rem;
 `;
 
 const ImageText = styled.div`
@@ -110,15 +110,15 @@ const ImageText = styled.div`
 
   h1 {
     color: #c8604e;
-    font-size: 24px;
+    font-size: 2.4rem;
     font-weight: 700;
-    line-height: 160%; /* 38.4px */
+    line-height: 160%; /* 3.84rem */
   }
   p {
     color: #dab3ac;
-    font-size: 14px;
+    font-size: 1.4rem;
     font-weight: 400;
-    line-height: 160%; /* 22.4px */
+    line-height: 160%; /* 2.2399999999999998rem */
   }
 `;
 
@@ -127,21 +127,21 @@ const Description = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 3px;
+  gap: 0.3rem;
 
   h1 {
     text-align: center;
     color: #525252;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 600;
-    line-height: 150%; /* 27px */
+    line-height: 150%; /* 2.7rem */
   }
   p {
     text-align: center;
     color: #737373;
-    font-size: 14px;
+    font-size: 1.4rem;
     font-weight: 400;
-    line-height: 140%; /* 19.6px */
+    line-height: 140%; /* 1.9600000000000002rem */
     word-break: keep-all;
   }
 `;

--- a/src/components/home/NotificationModal.tsx
+++ b/src/components/home/NotificationModal.tsx
@@ -49,36 +49,36 @@ export default function NotificationModal({
 
 const Article = styled.article<{ $index: number }>`
   position: fixed;
-  top: ${({ $index }) => `${124 + $index * 50}px`};
-  left: ${({ $index }) => `${164 + $index * 40}px`};
-  width: 405px;
-  border-radius: 15px;
+  top: ${({ $index }) => `${12.4 + $index * 5.0}rem`};
+  left: ${({ $index }) => `${16.4 + $index * 4.0}rem`};
+  width: 40.5rem;
+  border-radius: 1.5rem;
   background-color: #fff;
 `;
 const ContentsWapper = styled.div`
-  max-height: 600px;
+  max-height: 60rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 49px 43px 75px;
-  border-radius: 15px;
+  padding: 4.9rem 4.3rem 7.5rem;
+  border-radius: 1.5rem;
 
   > a {
-    margin-top: 35px;
+    margin-top: 3.5rem;
     line-height: 170%;
-    font-size: 16px;
+    font-size: 1.6rem;
     color: #737373;
     text-decoration: underline;
     text-underline-position: under;
   }
 `;
 const ImageContainer = styled.div`
-  width: 56px;
-  height: 56px;
-  margin-bottom: 11px;
+  width: 5.6rem;
+  height: 5.6rem;
+  margin-bottom: 1.1rem;
 `;
 const Title = styled.h1`
-  font-size: 30px;
+  font-size: 3rem;
   font-weight: bold;
   color: #222222;
   line-height: 140%;
@@ -91,12 +91,12 @@ const MainText = styled.div`
 
   /* code start: scrollbar css design */
   &::-webkit-scrollbar {
-    width: 17px; // border-left 5px, border-right 5px를 뺀 7px가 보이는 두께
+    width: 1.7rem; // border-left 0.5rem, border-right 5px를 뺀 7px가 보이는 두께
   }
   &::-webkit-scrollbar-thumb {
     background: #737373;
-    border-radius: 10px;
-    border: 5px solid #fff; // 컨텐츠 배경색과 같은 흰색 border를 줌으로써 스크롤바 오른쪽 여백을 구현
+    border-radius: 1rem;
+    border: 0.5rem solid #fff; // 컨텐츠 배경색과 같은 흰색 border를 줌으로써 스크롤바 오른쪽 여백을 구현
     // 스크롤바의 border-radius까지 figma대로 구현하려면 위처럼 상하좌우 전체에 border를 주고 border-radius를 적용시켜야 함.
   }
   // 스크롤바 위아래 여백
@@ -104,41 +104,41 @@ const MainText = styled.div`
   &::-webkit-scrollbar-button:vertical:end:decrement // 아래 여백
   {
     display: block;
-    height: 23px; // 위아래 여백을 28px 주어야 하는데, border-top, border-bottom이 5px 있으므로 23px만
+    height: 2.3rem; // 위아래 여백을 2.8rem 주어야 하는데, border-top, border-bottom이 0.5rem 있으므로 23px만
   }
   /* end */
 `;
 const ButtonWrapper = styled.div`
-  height: 73px;
+  height: 7.3rem;
   background-color: #f0745f;
-  border-radius: 0 0 15px 15px;
+  border-radius: 0 0 1.5rem 1.5rem;
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
 `;
 const Button = styled.button`
-  font-size: 18px;
+  font-size: 1.8rem;
   letter-spacing: -5%;
   color: #fff;
   text-align: center;
-  line-height: 73px;
+  line-height: 7.3rem;
   border: none;
   background-color: transparent;
   cursor: pointer;
 `;
 const DivideLine = styled.div`
   width: 0;
-  height: 30px;
-  border-left: 1px solid #fff;
+  height: 3rem;
+  border-left: 0.1rem solid #fff;
 `;
 
 const MarkdownStyledWrapper = styled.div`
-  font-size: 16px;
+  font-size: 1.6rem;
   line-height: 170%;
   letter-spacing: 0;
   color: #737373;
   p {
-    margin-top: 18px;
+    margin-top: 1.8rem;
     white-space: pre-wrap;
     word-break: keep-all;
   }

--- a/src/components/home/Service.tsx
+++ b/src/components/home/Service.tsx
@@ -66,7 +66,7 @@ export default function Service() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  padding: 100px 0;
+  padding: 10rem 0;
 
   display: grid;
   grid-template-areas:
@@ -82,22 +82,22 @@ const Section = styled.section`
 
 const Container = styled.div<{ $appIndex: number }>`
   display: flex;
-  padding-bottom: 60px;
+  padding-bottom: 6rem;
   align-items: center;
-  width: 526px;
+  width: 52.6rem;
   overflow: hidden;
 
   > div {
     transition: transform 0.5s ease-in-out;
-    transform: translateX(${(p) => p.$appIndex * -526}px);
+    transform: translateX(${(p) => p.$appIndex * -52.6}rem);
   }
 `;
 
 const App = styled.div<{ $clickable: boolean }>`
   display: grid;
   flex-direction: column;
-  font-size: 14px;
-  letter-spacing: -0.2px;
+  font-size: 1.4rem;
+  letter-spacing: -0.02rem;
   width: 100%;
   cursor: ${(props) => (props.$clickable ? "pointer" : "default")};
 
@@ -107,28 +107,28 @@ const App = styled.div<{ $clickable: boolean }>`
     "name mobile"
     "desc mobile"
     "x2 mobile";
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: 20rem 1fr;
   grid-template-rows: 1fr auto auto auto 1fr;
-  grid-column-gap: 20px;
+  grid-column-gap: 2rem;
   justify-items: center;
 
   > img {
-    width: 210px;
-    height: 210px;
+    width: 21rem;
+    height: 21rem;
     object-fit: cover;
     grid-area: logo;
-    border-radius: 26px;
+    border-radius: 2.6rem;
   }
   #siksha {
-    width: 120px;
-    height: 120px;
+    width: 12rem;
+    height: 12rem;
     object-fit: cover;
-    margin: 25px 0;
+    margin: 2.5rem 0;
   }
   h3 {
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: bold;
-    margin-bottom: 12px;
+    margin-bottom: 1.2rem;
     grid-area: name;
   }
   div:nth-child(3) {
@@ -137,32 +137,32 @@ const App = styled.div<{ $clickable: boolean }>`
   }
   > div:last-child {
     grid-area: mobile;
-    width: 306px;
-    height: 582px;
+    width: 30.6rem;
+    height: 58.2rem;
     background: url("/image/mobileFrame.svg") no-repeat;
-    background-size: 306px 582px;
+    background-size: 30.6rem 58.2rem;
     display: flex;
     justify-content: center;
     align-items: center;
     img {
-      width: 306px;
-      height: 582px;
-      border-radius: 26px;
+      width: 30.6rem;
+      height: 58.2rem;
+      border-radius: 2.6rem;
     }
     #siksha2 {
-      width: 282px;
-      height: 556px;
+      width: 28.2rem;
+      height: 55.6rem;
     }
   }
 `;
 
 const LeftRightButton = styled.button`
-  width: 22px;
-  height: 39px;
-  background-size: 22px 39px;
+  width: 2.2rem;
+  height: 3.9rem;
+  background-size: 2.2rem 3.9rem;
   background-repeat: no-repeat;
   cursor: ${(props) => (props.disabled ? "default" : "pointer")};
-  margin: 60px;
+  margin: 6rem;
 `;
 
 const LeftButton = styled(LeftRightButton)`

--- a/src/components/home/ToHomePage.tsx
+++ b/src/components/home/ToHomePage.tsx
@@ -14,20 +14,20 @@ export default function ToHomePage() {
 const Section = styled.section`
   position: relative;
   width: 100%;
-  height: 100px;
+  height: 10rem;
   display: flex;
   justify-content: center;
   align-items: center;
 
   background: #f5d487;
-  box-shadow: 0px 5px 5px 0px rgba(219, 108, 89, 0.8);
+  box-shadow: 0rem 0.5rem 0.5rem 0rem rgba(219, 108, 89, 0.8);
 `;
 
 const CustomLink = styled(Link)`
   color: #735614;
   text-align: center;
   font-family: Jalnan;
-  font-size: 22px;
+  font-size: 2.2rem;
   font-style: normal;
   font-weight: 700;
   line-height: normal;

--- a/src/components/home/common.tsx
+++ b/src/components/home/common.tsx
@@ -2,28 +2,28 @@ import styled from "styled-components";
 
 export const SectionNumber = styled.div`
   display: inline-flex;
-  margin-bottom: 10px;
-  padding: 5px 18px 1px 18px;
-  border-radius: 28.5px;
-  border: 1px solid #f0745f;
+  margin-bottom: 1rem;
+  padding: 0.5rem 1.8rem 0.1rem 1.8rem;
+  border-radius: 2.85rem;
+  border: 0.1rem solid #f0745f;
   color: #f0745f;
   font-family: Jalnan;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 700;
-  letter-spacing: 1px;
+  letter-spacing: 0.1rem;
 `;
 
 export const SectionTitle = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 7px;
-  margin-bottom: 90px;
+  gap: 0.7rem;
+  margin-bottom: 9rem;
 
   h1 {
     color: #2f2f2f;
     font-family: Jalnan;
-    font-size: 40px;
+    font-size: 4rem;
     font-weight: 700;
     line-height: 160%;
     span {
@@ -33,7 +33,7 @@ export const SectionTitle = styled.div`
   }
   p {
     color: #737373;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 500;
   }
 `;

--- a/src/components/recruit/RecruitItem.tsx
+++ b/src/components/recruit/RecruitItem.tsx
@@ -61,25 +61,25 @@ export function RecruitItem({
 const Container = styled.div<{ $isActive: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 48px;
+  gap: 0.8rem;
+  padding: 4.8rem;
   --color: ${({ $isActive }) => ($isActive ? "#3F3F3F" : "#AAA")};
   color: var(--color);
 
   // XXX 활성화 시에는 글자색과 동일한데 비활성화 시 글자색하고 다른 건 의도된 건가??
-  border-left: 5px solid
+  border-left: 0.5rem solid
     ${({ $isActive }) => ($isActive ? "#3F3F3F" : "#C8C8C8")};
   background: #fff;
-  box-shadow: -4px 0px 10px 0px rgba(0, 0, 0, 0.04);
+  box-shadow: -0.4rem 0rem 1rem 0rem rgba(0, 0, 0, 0.04);
 
   transition: 0.5s ease;
   cursor: pointer;
-  --arrow-gap: 22px;
+  --arrow-gap: 2.2rem;
 
   &:hover {
-    box-shadow: -4px 0px 20px 0px rgba(0, 0, 0, 0.08);
+    box-shadow: -0.4rem 0rem 2rem 0rem rgba(0, 0, 0, 0.08);
     transform: scale(101%);
-    --arrow-gap: 42px;
+    --arrow-gap: 4.2rem;
   }
 `;
 
@@ -92,22 +92,22 @@ const RecruitNameArea = styled.div`
 
 const RecruitName = styled.h2`
   color: #3f3f3f;
-  font-size: 28px;
+  font-size: 2.8rem;
   font-weight: 600;
   line-height: 140%;
   white-space: nowrap;
 `;
 
 const RightArrow = styled.img`
-  width: 33px;
-  height: 33px;
+  width: 3.3rem;
+  height: 3.3rem;
 `;
 
 const RecruitDescriptionArea = styled.div`
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 20px;
+  gap: 1rem;
+  font-size: 2rem;
   font-weight: 400;
   line-height: 140%;
 `;
@@ -119,14 +119,14 @@ const RecruitPeriod = styled.div`
 
 const RecruitDescription = styled.div`
   flex: 1 1 auto;
-  min-width: 150px;
+  min-width: 15rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 `;
 
 const RecruitDescriptionSeperator = styled.div`
-  flex: 0 0 1px;
-  height: 20px;
+  flex: 0 0 0.1rem;
+  height: 2rem;
   background-color: var(--color);
 `;

--- a/src/components/rookie/Progress/PortfolioCard.tsx
+++ b/src/components/rookie/Progress/PortfolioCard.tsx
@@ -191,10 +191,10 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
 const EmptyCard = styled.li`
   position: relative;
   display: flex;
-  width: 840px;
-  height: 193px;
+  width: 84rem;
+  height: 19.3rem;
   flex-shrink: 0;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   animation: ${LoadingBackgroundBlink};
 `;
 
@@ -203,45 +203,45 @@ const Card = styled.li<{
 }>`
   position: relative;
   display: flex;
-  width: 840px;
-  height: 193px;
+  width: 84rem;
+  height: 19.3rem;
   flex-shrink: 0;
-  border-radius: 5px;
-  border: 1px solid #d1d1d1;
-  padding: 27px;
+  border-radius: 0.5rem;
+  border: 0.1rem solid #d1d1d1;
+  padding: 2.7rem;
   color: ${(props) => (props.$submit ? "#64CB3F" : "#F0745F")};
-  border: "1px solid #D1D1D1";
+  border: "0.1rem solid #D1D1D1";
   background: "#fff";
-  gap: 14px;
+  gap: 1.4rem;
   &:hover {
     background: "#f6f6f6";
   }
 `;
 
 const InfoSection = styled.div`
-  width: 266px;
+  width: 26.6rem;
 `;
 
 const FileSection = styled.div`
-  width: 237px;
+  width: 23.7rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  border-right: 1px solid #f6f6f6;
-  gap: 8px;
+  border-right: 0.1rem solid #f6f6f6;
+  gap: 0.8rem;
   color: #404040;
 `;
 
 const FileInputButton = styled.label`
-  padding: 7px 12px;
-  gap: 10px;
-  border-radius: 5px;
+  padding: 0.7rem 1.2rem;
+  gap: 1rem;
+  border-radius: 0.5rem;
   background: #f0745f;
   color: #fff;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 500;
-  line-height: 160%; /* 25.6px */
-  letter-spacing: 0.64px;
+  line-height: 160%; /* 2.56rem */
+  letter-spacing: 0.064rem;
   cursor: pointer;
 `;
 const FileInput = styled.input`
@@ -254,27 +254,27 @@ const FileInput = styled.input`
   visibility: hidden;
 `;
 const Files = styled.div`
-  width: calc(100% - 15px);
-  padding: 8px;
+  width: calc(100% - 1.5rem);
+  padding: 0.8rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  border-radius: 5px;
-  gap: 6px;
+  border-radius: 0.5rem;
+  gap: 0.6rem;
   background: #f6f6f6;
 `;
 const File = styled.div`
-  padding: 4px 8px;
-  border-radius: 25px;
-  border: 1px solid #d1d1d1;
+  padding: 0.4rem 0.8rem;
+  border-radius: 2.5rem;
+  border: 0.1rem solid #d1d1d1;
   background: #fff;
   color: #404040;
-  font-size: 12px;
+  font-size: 1.2rem;
   font-weight: 400;
-  line-height: 160%; /* 19.2px */
-  letter-spacing: 0.48px;
+  line-height: 160%; /* 1.92rem */
+  letter-spacing: 0.048rem;
   display: flex;
-  gap: 10px;
+  gap: 1rem;
   align-items: center;
   cursor: pointer;
   &:hover {
@@ -283,37 +283,37 @@ const File = styled.div`
 `;
 
 const DeleteButton = styled.button`
-  width: 16px;
-  height: 16px;
+  width: 1.6rem;
+  height: 1.6rem;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 10px;
+  padding: 1rem;
   &:hover {
     opacity: 0.5;
   }
 `;
 
 const LinkSection = styled.div`
-  width: 237px;
+  width: 23.7rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
+  gap: 0.8rem;
   color: #404040;
 `;
 
 const LinkInput = styled.input`
-  width: 260px;
-  padding: 7px 12px;
+  width: 26rem;
+  padding: 0.7rem 1.2rem;
   color: #404040;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   line-height: 160%;
-  letter-spacing: 0.64px;
+  letter-spacing: 0.064rem;
   border: none;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   background: #f6f6f6;
 
   &::placeholder {
@@ -322,17 +322,17 @@ const LinkInput = styled.input`
 `;
 
 const Name = styled.h1`
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: 600;
-  margin-top: 16px;
-  margin-bottom: 7px;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
 `;
 
 const Description = styled.p`
   color: #737373;
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
-  line-height: 160%; /* 22.4px */
-  letter-spacing: 0.56px;
+  line-height: 160%; /* 2.2399999999999998rem */
+  letter-spacing: 0.05600000000000001rem;
   margin: 0;
 `;

--- a/src/components/rookie/Progress/ProgressCard.tsx
+++ b/src/components/rookie/Progress/ProgressCard.tsx
@@ -44,12 +44,12 @@ const Card = styled.li<{
 }>`
   position: relative;
   box-sizing: border-box;
-  width: 280px;
-  height: 193px;
+  width: 28rem;
+  height: 19.3rem;
   flex-shrink: 0;
-  border-radius: 5px;
-  border: 1px solid #d1d1d1;
-  padding: 27px;
+  border-radius: 0.5rem;
+  border: 0.1rem solid #d1d1d1;
+  padding: 2.7rem;
   cursor: pointer;
   color: ${(props) =>
     props.$theme === "green"
@@ -63,12 +63,12 @@ const Card = styled.li<{
       : "black"};
   border: ${(props) =>
     props.$theme === "green"
-      ? "1px solid #60BF3E"
+      ? "0.1rem solid #60BF3E"
       : props.$theme === "red"
-      ? "1px solid #F0745F"
+      ? "0.1rem solid #F0745F"
       : props.$theme === "yellow"
-      ? "1px solid #FFB800"
-      : "1px solid #D1D1D1"};
+      ? "0.1rem solid #FFB800"
+      : "0.1rem solid #D1D1D1"};
   background: ${(props) =>
     props.$theme === "green"
       ? "linear-gradient(180deg, #DBFFCE 0%, #FFF 46.88%);"
@@ -91,29 +91,29 @@ const Card = styled.li<{
 `;
 
 const Name = styled.h1`
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: 600;
-  margin-top: 16px;
-  margin-bottom: 7px;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
 `;
 
 const Description = styled.p`
   color: #737373;
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
-  line-height: 160%; /* 22.4px */
-  letter-spacing: 0.56px;
+  line-height: 160%; /* 2.2399999999999998rem */
+  letter-spacing: 0.05600000000000001rem;
   margin: 0;
 `;
 
 const Button = styled.button`
   position: absolute;
-  width: 30px;
-  height: 30px;
-  padding: 2px 0 0 0;
+  width: 3rem;
+  height: 3rem;
+  padding: 0.2rem 0 0 0;
   border-radius: 50%;
-  border: 1px solid #737373;
-  right: 27px;
-  bottom: 27px;
+  border: 0.1rem solid #737373;
+  right: 2.7rem;
+  bottom: 2.7rem;
   background: none;
 `;

--- a/src/components/rookie/Progress/ProgressList.tsx
+++ b/src/components/rookie/Progress/ProgressList.tsx
@@ -49,7 +49,7 @@ export function ProgressList({
 
 const List = styled.ul`
   display: flex;
-  gap: 20px;
+  gap: 2rem;
   list-style: none;
   padding: 0;
 `;

--- a/src/components/rookie/Progress/ResumeCard.tsx
+++ b/src/components/rookie/Progress/ResumeCard.tsx
@@ -31,16 +31,16 @@ const Card = styled.li<{
 }>`
   position: relative;
   box-sizing: border-box;
-  width: 280px;
-  height: 193px;
+  width: 28rem;
+  height: 19.3rem;
   flex-shrink: 0;
-  border-radius: 5px;
-  border: 1px solid #d1d1d1;
-  padding: 27px;
+  border-radius: 0.5rem;
+  border: 0.1rem solid #d1d1d1;
+  padding: 2.7rem;
   cursor: pointer;
   color: ${(props) => (props.$submit ? "#64CB3F" : "#F0745F")};
   border: ${(props) =>
-    props.$submit ? "1px solid #64CB3F" : "1px solid #D1D1D1"};
+    props.$submit ? "0.1rem solid #64CB3F" : "0.1rem solid #D1D1D1"};
   background: "#fff";
 
   &:hover {
@@ -49,29 +49,29 @@ const Card = styled.li<{
 `;
 
 const Name = styled.h1`
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: 600;
-  margin-top: 16px;
-  margin-bottom: 7px;
+  margin-top: 1.6rem;
+  margin-bottom: 0.7rem;
 `;
 
 const Description = styled.p`
   color: #737373;
-  font-size: 14px;
+  font-size: 1.4rem;
   font-weight: 400;
-  line-height: 160%; /* 22.4px */
-  letter-spacing: 0.56px;
+  line-height: 160%; /* 2.2399999999999998rem */
+  letter-spacing: 0.05600000000000001rem;
   margin: 0;
 `;
 
 const Button = styled.button`
   position: absolute;
-  width: 30px;
-  height: 30px;
-  padding: 2px 0 0 0;
+  width: 3rem;
+  height: 3rem;
+  padding: 0.2rem 0 0 0;
   border-radius: 50%;
-  border: 1px solid #737373;
-  right: 27px;
-  bottom: 27px;
+  border: 0.1rem solid #737373;
+  right: 2.7rem;
+  bottom: 2.7rem;
   background: none;
 `;

--- a/src/components/rookie/QuestionaireInput/QuestionaireInput.tsx
+++ b/src/components/rookie/QuestionaireInput/QuestionaireInput.tsx
@@ -42,21 +42,21 @@ const Wrapper = styled.li`
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0.6rem;
 `;
 const Question = styled.div`
   color: #404040;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 400;
-  line-height: 160%; /* 32px */
-  letter-spacing: 0.8px;
+  line-height: 160%; /* 3.2rem */
+  letter-spacing: 0.08rem;
 `;
 const TextArea = styled.textarea`
-  height: 214px;
-  padding: 15px;
+  height: 21.4rem;
+  padding: 1.5rem;
   flex-shrink: 0;
-  border-radius: 5px;
-  border: 1px solid #d9d9d9;
+  border-radius: 0.5rem;
+  border: 0.1rem solid #d9d9d9;
   background: #f6f6f6;
   resize: none;
   font: inherit;
@@ -67,11 +67,11 @@ const TextArea = styled.textarea`
 `;
 const Count = styled.div`
   position: absolute;
-  right: 32px;
-  bottom: 15px;
+  right: 3.2rem;
+  bottom: 1.5rem;
   color: #737373;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
-  line-height: 160%; /* 25.6px */
-  letter-spacing: 0.64px;
+  line-height: 160%; /* 2.56rem */
+  letter-spacing: 0.064rem;
 `;

--- a/src/components/rookie/UserInfoForm/LabeledSelect.tsx
+++ b/src/components/rookie/UserInfoForm/LabeledSelect.tsx
@@ -72,15 +72,15 @@ const Options = styled.div<{ $isOpen: boolean }>`
   display: ${(props) => (props.$isOpen ? "block" : "none")};
 
   width: 100%;
-  max-height: 200px;
+  max-height: 20rem;
   overflow: auto;
 
   position: absolute;
-  top: calc(100% - 1px);
+  top: calc(100% - 0.1rem);
 
   background: white;
-  border: 1px solid #404040;
-  border-radius: 0 0 2px 2px;
+  border: 0.1rem solid #404040;
+  border-radius: 0 0 0.2rem 0.2rem;
 
   // 커스텀 스크롤바 사용
   &::-webkit-scrollbar {
@@ -93,10 +93,10 @@ const Option = styled.button<{ $selected: boolean }>`
   align-items: center;
 
   width: 100%;
-  height: 40px;
-  padding: 0 12px;
+  height: 4rem;
+  padding: 0 1.2rem;
 
-  font-size: 16px;
+  font-size: 1.6rem;
   cursor: pointer;
   background-color: ${(props) => (props.$selected ? "#d9d9d9" : "white")};
 
@@ -111,13 +111,13 @@ const CurrentOption = styled.button<{ $isOpen: boolean }>`
   justify-content: space-between;
 
   width: 100%;
-  height: 40px;
-  padding: 0 12px;
+  height: 4rem;
+  padding: 0 1.2rem;
 
-  border: 1px solid #404040;
-  border-radius: ${(props) => (props.$isOpen ? "2px 2px 0 0" : "2px")};
+  border: 0.1rem solid #404040;
+  border-radius: ${(props) => (props.$isOpen ? "0.2rem 0.2rem 0 0" : "0.2rem")};
 
-  font-size: 16px;
+  font-size: 1.6rem;
   cursor: pointer;
   background-color: white;
 

--- a/src/components/rookie/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/rookie/UserInfoForm/UserInfoForm.tsx
@@ -78,8 +78,8 @@ export const Container = styled.form`
 
   grid-template-columns: 1fr 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
-  gap: 16px;
-  margin-bottom: 130px;
+  gap: 1.6rem;
+  margin-bottom: 13rem;
 `;
 export const Sep = styled.hr`
   grid-area: sep;
@@ -87,5 +87,5 @@ export const Sep = styled.hr`
   width: 0;
   height: 100%;
 
-  border-width: 0 1px;
+  border-width: 0 0.1rem;
 `;

--- a/src/components/solve/CodeEditor/EditorToggle.tsx
+++ b/src/components/solve/CodeEditor/EditorToggle.tsx
@@ -23,38 +23,38 @@ const Wrapper = styled.button`
 
   display: flex;
   align-items: center;
-  gap: 15px;
+  gap: 1.5rem;
 
   background: none;
   border: none;
-  font-size: 18px;
+  font-size: 1.8rem;
   color: #342d29;
   cursor: pointer;
 `;
 
 const Slot = styled.div`
-  width: 84px;
-  height: 36px;
+  width: 8.4rem;
+  height: 3.6rem;
   box-sizing: border-box;
-  padding-left: 2px;
+  padding-left: 0.2rem;
   position: relative;
 
-  border: 4px solid #373737;
-  border-radius: 18px;
+  border: 0.4rem solid #373737;
+  border-radius: 1.8rem;
 `;
 
 const TRANS_TIME = "0.2s";
 
 const Circle = styled.div<{ value: boolean }>`
-  width: 24px;
-  height: 24px;
+  width: 2.4rem;
+  height: 2.4rem;
 
   position: absolute;
-  top: 2px;
-  left: ${(props) => (props.value ? "2px" : "48px")};
+  top: 0.2rem;
+  left: ${(props) => (props.value ? "0.2rem" : "4.8rem")};
   transition: left ${TRANS_TIME} ease-in-out;
 
-  border: 4px solid #373737;
+  border: 0.4rem solid #373737;
   border-radius: 50%;
 
   background: #f0745f;
@@ -75,13 +75,13 @@ const OnText = styled(Text)<{ value: boolean }>`
   justify-content: flex-end;
 
   right: 0;
-  padding-right: 10px;
+  padding-right: 1rem;
   width: ${(props) => (props.value ? "100%" : "0")};
 `;
 
 const OffText = styled(Text)<{ value: boolean }>`
   justify-content: flex-start;
 
-  padding-left: 10px;
+  padding-left: 1rem;
   width: ${(props) => (props.value ? "0" : "100%")};
 `;

--- a/src/components/solve/CodeEditor/LanguageSelection.tsx
+++ b/src/components/solve/CodeEditor/LanguageSelection.tsx
@@ -13,8 +13,8 @@ export default function LanguageSelection(props: Props) {
   return (
     <Wrapper>
       <ListToggleButton onClick={() => setIsOpen(!isOpen)} $isOpen={isOpen}>
-        <span>{props.language}</span>
-        <img src="/icon/OpenSelect.svg" alt="▼" />
+        <ListToggleButtonLabel>{props.language}</ListToggleButtonLabel>
+        <img src="/icon/OpenSelect.svg" alt="▼" width="21rem" />
       </ListToggleButton>
       {isOpen && (
         <List>
@@ -39,14 +39,14 @@ export default function LanguageSelection(props: Props) {
 
 const Wrapper = styled.div`
   position: relative;
-  width: 128px;
+  width: 12.8rem;
   height: fit-content;
 `;
 
 const Button = styled.button`
   width: 100%;
-  height: 35px;
-  padding: 0 5px;
+  height: 3.5rem;
+  padding: 0 0.5rem;
 
   cursor: pointer;
   font-weight: 600;
@@ -62,13 +62,17 @@ const Button = styled.button`
 
 const ListToggleButton = styled(Button)<{ $isOpen: boolean }>`
   background: white;
-  border: 4px solid #373737;
-  border-radius: 5px;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem;
   position: relative;
 
   img {
     transform: rotate(${({ $isOpen }) => ($isOpen ? "-180deg" : "0deg")});
   }
+`;
+
+const ListToggleButtonLabel = styled.span`
+  font-size: 1.33rem;
 `;
 
 const ListItemButton = styled(Button)<{ $selected: boolean }>`
@@ -83,7 +87,7 @@ const ListItemButton = styled(Button)<{ $selected: boolean }>`
 const List = styled.ul`
   position: absolute;
   box-sizing: border-box;
-  top: calc(100% - 5px);
+  top: calc(100% - 0.5rem);
   left: 0;
   width: 100%;
 
@@ -92,9 +96,9 @@ const List = styled.ul`
   list-style: none;
 
   background: white;
-  border: 4px solid #373737;
-  border-radius: 5px;
-  max-height: 200px;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem;
+  max-height: 20rem;
   overflow-y: auto;
 
   z-index: ${zIndex.selectOptions};

--- a/src/components/solve/CodeEditor/index.tsx
+++ b/src/components/solve/CodeEditor/index.tsx
@@ -38,7 +38,7 @@ export default function CodeEditor({
       {/* Header가 Editor를 가리도록, Header를 먼저 배치. 실제 렌더 위치는 grid에 의해 보정됨 */}
       <EditorWrapper ref={(elem) => setContainer(elem ?? undefined)} />
       <Header>
-        <span>Script</span>
+        <HeaderTitle>Script</HeaderTitle>
         <FullscreenButton
           onClick={() => setIsFullScreen(!isFullScreen)}
           $isFullScreen={isFullScreen}
@@ -59,7 +59,7 @@ const Section = styled.section`
   grid-template-rows: auto 1fr;
   grid-template-columns: auto auto 1fr auto;
 
-  min-width: 295px; // 탭 모양이 안 깨지는 크기
+  min-width: 29.5rem; // 탭 모양이 안 깨지는 크기
 
   /* Solve page layout */
   flex: 1;
@@ -68,15 +68,16 @@ const Section = styled.section`
 
 const Header = styled.h3`
   background: url("/image/TabHeader.svg");
+  background-size: 88.5rem;
 
   display: flex;
   align-items: center;
 
-  padding-left: 32px;
-  padding-right: 32px;
-  height: 47px;
-  width: 293px;
-  margin: 0 0 -4px 0; // 탭 헤더로 테두리 일부를 가린다
+  padding-left: 3.2rem;
+  padding-right: 3.2rem;
+  height: 4.7rem;
+  width: 29.3rem;
+  margin: 0 0 -0.4rem 0; // 탭 헤더로 테두리 일부를 가린다
   box-sizing: border-box;
 
   grid-row: 1;
@@ -88,10 +89,14 @@ const Header = styled.h3`
   }
 `;
 
+const HeaderTitle = styled.span`
+  font-size: 1.6rem;
+`;
+
 const EditorWrapper = styled.div`
-  border: 4px solid #373737;
-  border-bottom-width: 2px;
-  border-radius: 0 4px 4px 4px;
+  border: 0.4rem solid #373737;
+  border-bottom-width: 0.2rem;
+  border-radius: 0 0.4rem 0.4rem 0.4rem;
 
   flex: 1;
   overflow: auto;
@@ -102,25 +107,27 @@ const EditorWrapper = styled.div`
 
   .cm-editor * {
     font-family: monospace;
+    font-size: 1.3rem;
   }
 `;
 
 const FullscreenButton = styled.button<{ $isFullScreen: boolean }>`
-  width: 20px;
-  height: 20px;
+  width: 2rem;
+  height: 2rem;
 
   border: none;
   background: url("${(props) =>
     props.$isFullScreen
       ? "/icon/ExitFullScreen.svg"
       : "/icon/FullScreen.svg"}");
+  background-size: 2rem;
   cursor: pointer;
 `;
 
 const Version = styled.span`
-  font-size: 12px;
+  font-size: 1.2rem;
   color: #373737;
-  margin-left: 8px;
+  margin-left: 0.8rem;
   display: flex;
   align-items: center;
 `;

--- a/src/components/solve/ProblemDescription/ProblemDescription.tsx
+++ b/src/components/solve/ProblemDescription/ProblemDescription.tsx
@@ -61,16 +61,16 @@ export default function ProblemDescription({
         markdownString={problemMarkdown}
         StyledWrapper={MarkdownStyledWrapper}
       />
-      <HorizontalLine margin="25px 0 14px 0" />
+      <HorizontalLine margin="2.5rem 0 1.4rem 0" />
       {/**
       // TODO: 문제설명 마크다운에 디자인 추가
       <BoldText>제한사항</BoldText>
       <Text>
         <MarkDownRenderer markdownString={`-100,000 ≤ a, b ≤ 100,000`} />
       </Text>
-      <HorizontalLine margin="17px 0 14px 0" />
+      <HorizontalLine margin="1.7rem 0 1.4rem 0" />
        */}
-      <BoldText margin="0 0 16px 0">입출력 예시</BoldText>
+      <BoldText margin="0 0 1.6rem 0">입출력 예시</BoldText>
       <TestCaseTable
         defaultTestCases={defaultTestCases}
         customTestCases={customTestCases}
@@ -93,19 +93,19 @@ export default function ProblemDescription({
 /* end */
 
 const Section = styled.section`
-  border: 4px solid #373737;
-  border-radius: 5px;
-  padding: 28px 26px;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem;
+  padding: 2.8rem 2.6rem;
   overflow-y: auto;
 
   /* code start: scrollbar css design */
   &::-webkit-scrollbar {
-    width: 17px; // border-left 5px, border-right 5px를 뺀 7px가 보이는 두께
+    width: 1.7rem; // border-left 0.5rem, border-right 5px를 뺀 7px가 보이는 두께
   }
   &::-webkit-scrollbar-thumb {
     background: #373737;
-    border-radius: 10px;
-    border: 5px solid #fff; // 컨텐츠 배경색과 같은 흰색 border를 줌으로써 스크롤바 오른쪽 여백을 구현
+    border-radius: 1rem;
+    border: 0.5rem solid #fff; // 컨텐츠 배경색과 같은 흰색 border를 줌으로써 스크롤바 오른쪽 여백을 구현
     // 스크롤바의 border-radius까지 figma대로 구현하려면 위처럼 상하좌우 전체에 border를 주고 border-radius를 적용시켜야 함.
   }
   // 스크롤바 위아래 여백
@@ -113,7 +113,7 @@ const Section = styled.section`
   &::-webkit-scrollbar-button:vertical:end:decrement // 아래 여백
   {
     display: block;
-    height: 23px; // 위아래 여백을 28px 주어야 하는데, border-top, border-bottom이 5px 있으므로 23px만
+    height: 2.3rem; // 위아래 여백을 2.8rem 주어야 하는데, border-top, border-bottom이 0.5rem 있으므로 23px만
   }
   /* end */
 
@@ -127,30 +127,30 @@ const Section = styled.section`
 
 const ProblemTitle = styled.h1`
   font-weight: bold;
-  font-size: 40px;
-  margin-bottom: 28px;
+  font-size: 4rem;
+  margin-bottom: 2.8rem;
 `;
 
 const AddTestCaseButton = styled.button`
   float: right;
-  margin-top: 16px;
-  padding: 8px;
-  width: 216px;
-  height: 39px;
+  margin-top: 1.6rem;
+  padding: 0.8rem;
+  width: 21.6rem;
+  height: 3.9rem;
 
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: 0.7rem;
 
   background-color: #fff;
-  border: 2px solid #373737;
-  border-radius: 6px;
+  border: 0.2rem solid #373737;
+  border-radius: 0.6rem;
   cursor: pointer;
 
   > img {
-    width: 24px;
-    height: 24px;
+    width: 2.4rem;
+    height: 2.4rem;
   }
 
   > div {
@@ -164,21 +164,21 @@ const AddTestCaseButton = styled.button`
 
 const MarkdownStyledWrapper = styled.div`
   h1 {
-    font-size: 40px;
+    font-size: 4rem;
     line-height: 160%;
   }
   h2 {
     font-weight: 600;
-    font-size: 32px;
+    font-size: 3.2rem;
     line-height: 160%;
   }
   h3 {
     font-weight: 500;
-    font-size: 24px;
+    font-size: 2.4rem;
     line-height: 160%;
   }
   p {
-    font-size: 18px;
+    font-size: 1.8rem;
     line-height: 160%;
   }
   ul,
@@ -193,15 +193,15 @@ const MarkdownStyledWrapper = styled.div`
     font-family: Consolas, Monaco, Lucida Console, Liberation Mono,
       DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace;
     color: #f0745f;
-    border-radius: 3px;
+    border-radius: 0.3rem;
   }
   pre {
     background: rgba(135, 131, 120, 0.15);
     white-space: pre-wrap !important;
-    padding: 1em 20px;
+    padding: 1em 2rem;
     code {
       background: none;
-      padding: 0px !important;
+      padding: 0rem !important;
       line-height: 2em !important;
     }
   }

--- a/src/components/solve/ProblemDescription/TestCaseInputs.tsx
+++ b/src/components/solve/ProblemDescription/TestCaseInputs.tsx
@@ -111,7 +111,7 @@ const TestCaseInputTextarea = styled.textarea`
   width: 100%;
   background: transparent;
   border: none;
-  font-size: 18px;
+  font-size: 1.8rem;
   line-height: 160%;
   resize: none;
 

--- a/src/components/solve/ProblemDescription/TestCaseModal.tsx
+++ b/src/components/solve/ProblemDescription/TestCaseModal.tsx
@@ -40,7 +40,12 @@ export default function TestCaseModal({
     <Article>
       <Nav>
         <CloseButton onClick={onClose}>
-          <img src="/icon/CloseModal.svg" alt="X" width="35px" height="35px" />
+          <img
+            src="/icon/CloseModal.svg"
+            alt="X"
+            width="3.5rem"
+            height="3.5rem"
+          />
         </CloseButton>
       </Nav>
 
@@ -54,12 +59,14 @@ export default function TestCaseModal({
 
         {/* 추가된 customTestCases가 없는 경우 위 TestCaseTable 컴포넌트에 hr 구분선이 없다 */}
         {/* 해당 경우에만 따로 구분선 추가 */}
-        {customTestCases.length === 0 && <HorizontalLine margin="20px 0" />}
+        {customTestCases.length === 0 && <HorizontalLine margin="2.0rem 0" />}
 
         {/* textareas table*/}
         {newCustomTestCaseInputs.length !== 0 && (
           // 추가된 customeTestCase가 아직 없는 경우만 디자인을 위해 margin-top 적용
-          <Table margin={`${customTestCases.length === 0 ? 0 : "10px 0 0 0"}`}>
+          <Table
+            margin={`${customTestCases.length === 0 ? 0 : "1.0rem 0 0 0"}`}
+          >
             <TestCaseInputs
               newCustomTestCaseInputs={newCustomTestCaseInputs}
               startIdx={defaultTestCases.length + customTestCases.length + 1}
@@ -107,19 +114,19 @@ const Article = styled.article`
 `;
 
 const Nav = styled.nav`
-  height: 54px;
-  padding: 9.5px;
+  height: 5.4rem;
+  padding: 0.95rem;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  border: 4px solid #373737;
-  border-radius: 5px 5px 0 0;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem 0.5rem 0 0;
   background-color: #f0745f;
 `;
 
 const CloseButton = styled.button`
-  width: 35px;
-  height: 35px;
+  width: 3.5rem;
+  height: 3.5rem;
   padding: 0;
   background: transparent;
   border: none;
@@ -129,12 +136,12 @@ const CloseButton = styled.button`
 const Main = styled.div`
   width: 100%;
   height: 100%;
-  padding: 30px;
+  padding: 3rem;
   display: flex;
   flex-direction: column;
-  border: 4px solid #373737;
+  border: 0.4rem solid #373737;
   border-top: none;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 0.5rem 0.5rem;
   background-color: #fff;
 
   overflow: auto;
@@ -145,20 +152,20 @@ const Main = styled.div`
 `;
 
 const Title = styled.h1`
-  margin: 0 0 23px 0;
+  margin: 0 0 2.3rem 0;
   font-weight: bold;
-  font-size: 40px;
+  font-size: 4rem;
 `;
 
 const AddTestCaseButton = styled.button<{ $marginTop: boolean }>`
   padding: 0;
-  margin-top: ${(props) => (props.$marginTop ? "10px" : 0)};
+  margin-top: ${(props) => (props.$marginTop ? "1.0rem" : 0)};
   width: 100%;
-  height: 70px;
-  min-height: 70px;
+  height: 7rem;
+  min-height: 7rem;
   background: #f6f6f6;
   border: none;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   color: #373737;
   cursor: pointer;
   &:hover {
@@ -169,21 +176,21 @@ const AddTestCaseButton = styled.button<{ $marginTop: boolean }>`
 const SubmitButton = styled.button`
   align-self: flex-end;
   font-weight: 600;
-  width: 80px;
-  padding: 9px 20px;
-  margin-top: 40px;
-  border: 4px solid #373737;
-  border-radius: 5px;
-  box-shadow: 4px 4px #323232;
-  font-size: 18px;
+  width: 8rem;
+  padding: 0.9rem 2rem;
+  margin-top: 4rem;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem;
+  box-shadow: 0.4rem 0.4rem #323232;
+  font-size: 1.8rem;
   line-height: 160%;
   letter-spacing: 5%;
   background: #f0745f;
   color: #323232;
   cursor: pointer;
   &:active {
-    box-shadow: 2px 2px #323232;
-    transform: translate(2px, 2px);
+    box-shadow: 0.2rem 0.2rem #323232;
+    transform: translate(0.2rem, 0.2rem);
   }
   &:hover {
     background: #fff;

--- a/src/components/solve/ProblemDescription/TestCaseTable.tsx
+++ b/src/components/solve/ProblemDescription/TestCaseTable.tsx
@@ -46,7 +46,7 @@ export default function TestCaseTable({
         {customTestCases.length !== 0 && (
           <tr style={{ width: "100%" }}>
             <td style={{ display: "block", width: "100%" }}>
-              <HorizontalLine margin="5px 0" />
+              <HorizontalLine margin="0.5rem 0" />
             </td>
           </tr>
         )}

--- a/src/components/solve/ProblemDescription/common.tsx
+++ b/src/components/solve/ProblemDescription/common.tsx
@@ -9,7 +9,7 @@ export interface TestCase {
 
 export const Text = styled.p<SpacerProps>`
   ${spacer}
-  font-size: 18px;
+  font-size: 1.8rem;
   line-height: 160%;
 `;
 
@@ -19,7 +19,7 @@ export const BoldText = styled(Text)`
 
 export const HorizontalLine = styled.hr<SpacerProps>`
   ${spacer}
-  height: 1px;
+  height: 0.1rem;
 `;
 
 export const Table = styled.table<SpacerProps>`
@@ -28,14 +28,14 @@ export const Table = styled.table<SpacerProps>`
   > tbody {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 1rem;
   }
 `;
 
 export const TableHeader = styled.tr`
   display: grid;
-  grid-template-columns: 60px 1fr 1fr;
-  gap: 10px;
+  grid-template-columns: 6rem 1fr 1fr;
+  gap: 1rem;
   > td {
     > pre {
       font-family: Pretendard;
@@ -49,8 +49,8 @@ export const TableItem = styled(TableHeader)`
   > th,
   td {
     background-color: #f6f6f6;
-    padding: 10px 15px;
-    border-radius: 5px;
+    padding: 1rem 1.5rem;
+    border-radius: 0.5rem;
   }
   > td:focus-within {
     background-color: #e6e6e6;
@@ -94,8 +94,8 @@ export function DeletableTableItem({
 const DeletableTableRow = styled(TableHeader)`
   td {
     background-color: #f6f6f6;
-    padding: 10px 15px;
-    border-radius: 5px;
+    padding: 1rem 1.5rem;
+    border-radius: 0.5rem;
   }
   > td:focus-within {
     background-color: #e6e6e6;
@@ -109,7 +109,7 @@ const DeletableTh = styled.th`
     width: 100%;
     height: 100%;
     color: #323232;
-    border-radius: 5px;
+    border-radius: 0.5rem;
     animation: appear 300ms;
     @keyframes appear {
       from {
@@ -119,8 +119,8 @@ const DeletableTh = styled.th`
   }
   > button {
     display: block;
-    padding: 13.2px 17.5px;
-    font-size: 14px;
+    padding: 1.3199999999999998rem 1.75rem;
+    font-size: 1.4rem;
     font-weight: bold;
     line-height: 160%;
     letter-spacing: 5%;
@@ -134,7 +134,7 @@ const DeletableTh = styled.th`
     }
   }
   > p {
-    padding: 10px 15px;
+    padding: 1rem 1.5rem;
     background-color: #f6f6f6;
   }
 `;

--- a/src/components/solve/TestResultConsole.tsx
+++ b/src/components/solve/TestResultConsole.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function TestResultConsole(props: Props) {
   return (
     <Section>
-      <h3>Console</h3>
+      <SectionTitle>Console</SectionTitle>
       <ul ref={props.ulRef}>
         {props.results.map((result) => (
           <li key={result.num}>
@@ -44,14 +44,14 @@ export default function TestResultConsole(props: Props) {
 }
 
 const Section = styled.section`
-  border: 4px solid #373737;
-  border-top-width: 2px;
-  border-radius: 5px;
+  border: 0.4rem solid #373737;
+  border-top-width: 0.2rem;
+  border-radius: 0.5rem;
 
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px;
+  gap: 1rem;
+  padding: 1rem;
 
   h3 {
     font-weight: bold;
@@ -60,7 +60,7 @@ const Section = styled.section`
   ul {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 1rem;
     line-height: 1.2;
     overflow: auto;
 
@@ -71,6 +71,10 @@ const Section = styled.section`
 
   /* Solve page layout */
   flex: 1;
+`;
+
+const SectionTitle = styled.h3`
+  font-size: 1.6rem;
 `;
 
 const Status = styled.p<{ $code: number }>`

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -53,8 +53,8 @@ const PreventGlobalStylesResetWrapper = styled.div`
     font-size: 2em;
     margin-block-start: 0.67em;
     margin-block-end: 0.67em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   h2 {
@@ -62,8 +62,8 @@ const PreventGlobalStylesResetWrapper = styled.div`
     font-size: 1.5em;
     margin-block-start: 0.83em;
     margin-block-end: 0.83em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   h3 {
@@ -71,16 +71,16 @@ const PreventGlobalStylesResetWrapper = styled.div`
     font-size: 1.17em;
     margin-block-start: 1em;
     margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   h4 {
     display: block;
     margin-block-start: 1.33em;
     margin-block-end: 1.33em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   h5 {
@@ -88,8 +88,8 @@ const PreventGlobalStylesResetWrapper = styled.div`
     font-size: 0.83em;
     margin-block-start: 1.67em;
     margin-block-end: 1.67em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   h6 {
@@ -97,16 +97,16 @@ const PreventGlobalStylesResetWrapper = styled.div`
     font-size: 0.67em;
     margin-block-start: 2.33em;
     margin-block-end: 2.33em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
     font-weight: bold;
   }
   p {
     display: block;
     margin-block-start: 1em;
     margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
   }
   em {
     font-style: italic;
@@ -119,18 +119,18 @@ const PreventGlobalStylesResetWrapper = styled.div`
     list-style: inside disc; // 공식 default는 outside이긴 하다.
     margin-block-start: 1em;
     margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 40px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
+    padding-inline-start: 4rem;
   }
   ol {
     display: block;
     list-style: inside decimal; // 공식 default는 outside이긴 하다.
     margin-block-start: 1em;
     margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
-    padding-inline-start: 40px;
+    margin-inline-start: 0rem;
+    margin-inline-end: 0rem;
+    padding-inline-start: 4rem;
   }
   code {
     /* font-family: monospace; */
@@ -140,7 +140,7 @@ const PreventGlobalStylesResetWrapper = styled.div`
     display: block;
     margin: 0;
     margin-top: 0;
-    margin-bottom: 16px;
+    margin-bottom: 1.6rem;
     padding: 0 1em;
     border-left: 0.25em solid #d0d7de;
     > p {

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -130,6 +130,7 @@ const Description = styled.h2`
   margin-top: 1.2rem;
   line-height: 140%;
   font-size: 1.6rem;
+  margin-bottom: 13.9rem;
   color: #484848;
   > span {
     font-weight: 500;

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -109,7 +109,7 @@ function ListItem({
               ? openedListItemIcon
               : closedListItemIcon
           }
-          style={{ width: "21px", height: "12px" }}
+          style={{ width: "2.1rem", height: "1.2rem" }}
         />
       </div>
     </ListItemRow>
@@ -117,19 +117,19 @@ function ListItem({
 }
 
 const Main = styled.main`
-  padding: 23vh max(50vw - 534px, 30px) 30px;
+  padding: 23vh max(50vw - 53.4rem, 3rem) 3rem;
 `;
 
 const Title = styled.h1`
-  font-size: 52px;
+  font-size: 5.2rem;
   font-weight: 600;
   color: #222222;
 `;
 
 const Description = styled.h2`
-  margin-top: 12px;
+  margin-top: 1.2rem;
   line-height: 140%;
-  font-size: 16px;
+  font-size: 1.6rem;
   color: #484848;
   > span {
     font-weight: 500;
@@ -144,16 +144,16 @@ const Mail = styled.a`
 `;
 
 const AnnouncementList = styled.ol`
-  margin-top: 50px;
-  min-width: 970px;
+  margin-top: 5rem;
+  min-width: 97rem;
 `;
 
 const ListRow = styled.li<{ $listItemState?: ListItemState }>`
   display: grid;
   grid-template-columns: 9fr 68fr 17fr 7fr;
-  font-size: 20px;
+  font-size: 2rem;
   line-height: 140%;
-  border-bottom: 1px solid #c9c9c9;
+  border-bottom: 0.1rem solid #c9c9c9;
 
   > p:nth-child(3) {
     text-align: center;
@@ -161,10 +161,10 @@ const ListRow = styled.li<{ $listItemState?: ListItemState }>`
 `;
 
 const ListHeaderRow = styled(ListRow)`
-  border-top: 2px solid #222222;
+  border-top: 0.2rem solid #222222;
   font-weight: 600;
   color: #222222;
-  padding: 16px 0;
+  padding: 1.6rem 0;
 
   > p:first-child {
     padding-left: 20%;
@@ -181,7 +181,7 @@ const ListItemRow = styled(ListRow)`
     }}
   ${({ $listItemState }) =>
     $listItemState === "SomethingElseSelected" && { color: "#9c9c9c" }}
-  padding: 30px 0 32px 0;
+  padding: 3.0rem 0 3.2rem 0;
 
   > p:first-child {
     padding-left: 30%;
@@ -197,23 +197,23 @@ const ListItemRow = styled(ListRow)`
 `;
 
 const NoAnnouncements = styled.div`
-  border-bottom: 1px solid #c9c9c9;
-  height: 450px;
+  border-bottom: 0.1rem solid #c9c9c9;
+  height: 45rem;
   display: flex;
   align-items: center;
   justify-content: center;
   > p {
     color: #3c3c3c;
     font-weight: 500;
-    font-size: 20px;
+    font-size: 2rem;
     line-height: 140%;
   }
 `;
 
 const MarkdownStyledWrapper = styled.div`
   p {
-    margin-top: 46px;
-    font-size: 18px;
+    margin-top: 4.6rem;
+    font-size: 1.8rem;
     font-weight: normal;
     line-height: 185%;
     color: #373737;

--- a/src/pages/Announcement.tsx
+++ b/src/pages/Announcement.tsx
@@ -32,7 +32,7 @@ export default function Announcement() {
       <Main>
         <Title>공지사항</Title>
         <Description>
-          찾는 공지가 없다면 <a href={MAILTO_RECRUIT}>{MAILTO_RECRUIT}</a>{" "}
+          찾는 공지가 없다면 <Mail href={MAILTO_RECRUIT}>{MAILTO_RECRUIT}</Mail>{" "}
           이메일로 문의주세요.
         </Description>
         <AnnouncementList>
@@ -117,8 +117,7 @@ function ListItem({
 }
 
 const Main = styled.main`
-  margin-top: 7vh;
-  padding: 9vh max(calc(50vw - 650px), 30px);
+  padding: 23vh max(50vw - 534px, 30px) 30px;
 `;
 
 const Title = styled.h1`
@@ -137,6 +136,11 @@ const Description = styled.h2`
     text-decoration: underline;
     text-underline-position: under;
   }
+`;
+
+const Mail = styled.a`
+  font-weight: 500;
+  text-decoration-line: underline;
 `;
 
 const AnnouncementList = styled.ol`

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -119,49 +119,49 @@ const Main = styled.main`
   font-family: Pretendard, sans-serif;
   font-style: normal;
   line-height: normal;
-  padding: 23vh max(calc(50vw - 650px), 30px);
-  padding-bottom: 30px;
+  padding: 23vh max(calc(50vw - 65rem), 3rem);
+  padding-bottom: 3rem;
 `;
 
 const Title = styled.h1`
-  margin: 9px 0;
+  margin: 0.9rem 0;
 `;
 
 const TitleMarkdownStyledWrapper = styled.div`
   p {
     margin: 0;
     color: #222;
-    font-size: 46px;
+    font-size: 4.6rem;
     font-weight: 700;
   }
 `;
 
 const Description = styled.p`
-  margin-top: 12px;
-  margin-bottom: 35px;
+  margin-top: 1.2rem;
+  margin-bottom: 3.5rem;
 `;
 
 const DescriptionMarkdownStyledWrapper = styled.div`
   p {
     color: #373737;
-    font-size: 20px;
+    font-size: 2rem;
     font-weight: 500;
-    line-height: 160%; /* 32px */
-    letter-spacing: 0.8px;
+    line-height: 160%; /* 3.2rem */
+    letter-spacing: 0.08rem;
   }
 `;
 
 const Information = styled.div`
-  margin-bottom: 34px;
+  margin-bottom: 3.4rem;
 `;
 
 const InformationMarkdownStyledWrapper = styled.div`
   p {
     color: #737373;
-    font-size: 18px;
+    font-size: 1.8rem;
     font-weight: 400;
-    line-height: 170%; /* 30.6px */
-    letter-spacing: 0.72px;
+    line-height: 170%; /* 3.06rem */
+    letter-spacing: 0.072rem;
     margin: 0;
   }
   code {
@@ -171,15 +171,15 @@ const InformationMarkdownStyledWrapper = styled.div`
   ul,
   ol {
     padding: 0;
-    margin: 4px;
-    padding-left: 20px;
+    margin: 0.4rem;
+    padding-left: 2rem;
     li {
       font: inherit;
       color: #737373;
-      font-size: 18px;
+      font-size: 1.8rem;
       font-weight: 400;
-      line-height: 170%; /* 30.6px */
-      letter-spacing: 0.72px;
+      line-height: 170%; /* 3.06rem */
+      letter-spacing: 0.072rem;
     }
   }
 `;
@@ -187,21 +187,21 @@ const InformationMarkdownStyledWrapper = styled.div`
 const AnnouncementButton = styled.button`
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  padding: 10px 20px;
+  gap: 1rem;
+  padding: 1rem 2rem;
   background: #f0745f;
-  border: #f0745f 1px solid;
-  border-radius: 5px;
+  border: #f0745f 0.1rem solid;
+  border-radius: 0.5rem;
   color: #fff;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 500;
-  line-height: 25px;
-  margin-bottom: 34px;
+  line-height: 2.5rem;
+  margin-bottom: 3.4rem;
   cursor: pointer;
 
   > div {
-    width: 25px;
-    height: 25px;
+    width: 2.5rem;
+    height: 2.5rem;
     background: #fff;
     display: inline-flex;
     align-items: center;
@@ -235,18 +235,18 @@ const BottomContainer = styled.div`
 const Caution = styled.div`
   position: relative;
   color: #515151;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 400;
-  line-height: 160%; /* 28.8px */
-  letter-spacing: 0.72px;
-  margin-top: 25px;
+  line-height: 160%; /* 2.88rem */
+  letter-spacing: 0.072rem;
+  margin-top: 2.5rem;
 `;
 
 const CancelButton = styled.button`
   position: absolute;
   display: inline-block;
   right: 0;
-  margin-top: 153px;
+  margin-top: 15.3rem;
   background: none;
   border: none;
   cursor: pointer;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -51,7 +51,7 @@ export default function Home() {
   return (
     <>
       <Header />
-      <main style={{ minWidth: "920px" }}>
+      <main style={{ minWidth: "92.0rem" }}>
         {announcementModalHandlePairs
           .filter(({ announcement }) => {
             const KEY = localStorageKeyOfAnnouncementId(announcement.id);

--- a/src/pages/RecruitList.tsx
+++ b/src/pages/RecruitList.tsx
@@ -57,7 +57,7 @@ export default function RecruitList() {
 const Main = styled.main`
   display: flex;
   flex-direction: column;
-  padding: 23vh max(50vw - 534px, 30px) 0;
+  padding: 23vh max(50vw - 534px, 30px) 30px;
 `;
 
 const Title = styled.h1`

--- a/src/pages/RecruitList.tsx
+++ b/src/pages/RecruitList.tsx
@@ -57,22 +57,22 @@ export default function RecruitList() {
 const Main = styled.main`
   display: flex;
   flex-direction: column;
-  padding: 23vh max(50vw - 534px, 30px) 30px;
+  padding: 23vh max(50vw - 53.4rem, 3rem) 3rem;
 `;
 
 const Title = styled.h1`
   color: #222;
-  font-size: 52px;
+  font-size: 5.2rem;
   font-weight: 600;
-  margin-bottom: 12px;
+  margin-bottom: 1.2rem;
 `;
 
 const Description = styled.p`
   color: #484848;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   line-height: 140%;
-  margin-bottom: 139px;
+  margin-bottom: 13.9rem;
 `;
 
 const Mail = styled.a`
@@ -83,5 +83,5 @@ const Mail = styled.a`
 const RecruitItemList = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 36px;
+  gap: 3.6rem;
 `;

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -106,44 +106,44 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 1100px;
-  padding: 60px 0;
+  width: 110rem;
+  padding: 6rem 0;
 `;
 
 const LogoWrapper = styled.div`
-  margin-bottom: 48px;
+  margin-bottom: 4.8rem;
 `;
 
 const Title = styled.div`
   color: #222;
-  font-size: 52px;
+  font-size: 5.2rem;
   font-weight: 700;
-  margin-bottom: 36px;
+  margin-bottom: 3.6rem;
 `;
 const Emphasis = styled.span`
   color: #f0745f;
-  font-size: 64px;
+  font-size: 6.4rem;
   font-weight: 700;
 `;
 const Description = styled.div`
   color: #484848;
   text-align: center;
-  font-size: 24px;
+  font-size: 2.4rem;
   font-weight: 500;
   line-height: 150%;
-  margin-bottom: 36px;
+  margin-bottom: 3.6rem;
   word-break: keep-all;
 `;
 const Contact = styled.div`
   color: #484848;
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: 1.6rem;
   font-weight: 400;
   text-align: center;
   a {
     color: #484848;
     font-family: Pretendard;
-    font-size: 16px;
+    font-size: 1.6rem;
     font-weight: 500;
     text-decoration-line: underline;
     cursor: pointer;

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -186,50 +186,50 @@ const Main = styled.main`
   font-family: Pretendard, sans-serif;
   font-style: normal;
   line-height: normal;
-  padding: 23vh max(calc(50vw - 534px), 30px);
+  padding: 23vh max(calc(50vw - 53.4rem), 3rem);
 `;
 
 const Title = styled.h1`
   color: #000;
-  font-size: 40px;
+  font-size: 4rem;
   font-weight: 600;
   margin: 0;
-  margin-bottom: 8px;
+  margin-bottom: 0.8rem;
 `;
 const Description = styled.p`
   color: #737373;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 400;
-  line-height: 160%; /* 28.8px */
-  letter-spacing: 0.72px;
+  line-height: 160%; /* 2.88rem */
+  letter-spacing: 0.072rem;
   margin: 0;
-  margin-bottom: 41px;
+  margin-bottom: 4.1rem;
 `;
 const Questionaires = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: 41px;
+  gap: 4.1rem;
   width: 100%;
   padding: 0;
   list-style: none;
-  margin-bottom: 100px;
+  margin-bottom: 10rem;
 `;
 const Buttons = styled.div`
   width: 100%;
   display: flex;
   justify-content: flex-end;
-  gap: 25px;
+  gap: 2.5rem;
 `;
 const SaveButton = styled.button`
   display: inline-flex;
-  padding: 10px 20px;
+  padding: 1rem 2rem;
   justify-content: center;
   align-items: flex-start;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
   background: #f0f0f0;
   color: #737373;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 500;
   cursor: pointer;
 
@@ -240,14 +240,14 @@ const SaveButton = styled.button`
 `;
 const SubmitButton = styled.button`
   display: inline-flex;
-  padding: 10px 20px;
+  padding: 1rem 2rem;
   justify-content: center;
   align-items: flex-start;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   border: none;
   background: #f0745f;
   color: #fff;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 500;
   cursor: pointer;
 

--- a/src/pages/Solve.tsx
+++ b/src/pages/Solve.tsx
@@ -189,34 +189,34 @@ export default function Solve() {
 const Container = styled.div`
   display: flex;
   height: 100vh;
-  padding: 30px;
+  padding: 3rem;
   box-sizing: border-box;
   background: #fff7e9;
 `;
 const Main = styled.main`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 1.6rem;
   flex: 1;
   overflow: hidden;
-  border: 4px solid #373737;
-  box-shadow: 10px 10px #373737;
-  border-radius: 5px;
+  border: 0.4rem solid #373737;
+  box-shadow: 1rem 1rem #373737;
+  border-radius: 0.5rem;
   background: white;
 `;
 const TopNav = styled.nav`
   display: flex;
   align-items: center;
-  padding: 14px;
+  padding: 1.4rem;
   background: #f0745f;
-  border-bottom: 4px solid #373737;
+  border-bottom: 0.4rem solid #373737;
 
   a {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 0.8rem;
     font-weight: bold;
-    font-size: 16px;
+    font-size: 1.6rem;
     color: #000000;
     text-decoration: none;
   }
@@ -224,8 +224,8 @@ const TopNav = styled.nav`
 const Row = styled.div<{ $collapseLeft?: boolean }>`
   display: flex;
   flex: 1;
-  gap: ${(props) => (props.$collapseLeft ? "0" : "16px")};
-  padding: 0 16px 16px;
+  gap: ${(props) => (props.$collapseLeft ? "0" : "1.6rem")};
+  padding: 0 1.6rem 1.6rem;
   min-height: 0;
   & > :first-child {
     ${(props) =>
@@ -247,20 +247,20 @@ const BottomNav = styled.nav`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 16px;
-  padding: 16px 0 0;
+  gap: 1.6rem;
+  padding: 1.6rem 0 0;
 `;
 const SubmitButton = styled.button<{ $primary?: boolean }>`
-  padding: 9px 20px;
-  border: 4px solid #373737;
-  border-radius: 5px;
-  box-shadow: 4px 4px #323232;
-  font-size: 18px;
+  padding: 0.9rem 2rem;
+  border: 0.4rem solid #373737;
+  border-radius: 0.5rem;
+  box-shadow: 0.4rem 0.4rem #323232;
+  font-size: 1.8rem;
   background: ${(props) => (props.$primary ? "#f0745f" : "#ededed")};
   cursor: pointer;
   &:active {
-    box-shadow: 2px 2px #323232;
-    transform: translate(2px, 2px);
+    box-shadow: 0.2rem 0.2rem #323232;
+    transform: translate(0.2rem, 0.2rem);
   }
   &:disabled {
     background: #c4c4c4;

--- a/src/pages/Sso.tsx
+++ b/src/pages/Sso.tsx
@@ -168,43 +168,43 @@ const RegisterContainer = styled.div`
 
 const RegisterForm = styled.form`
   position: relative;
-  padding: 0 60px;
+  padding: 0 6rem;
   display: flex;
   flex-direction: column;
   background-color: #ffffff;
-  border-radius: 20px;
+  border-radius: 2rem;
 `;
 
 const RegisterIcon = styled.img`
-  margin-top: 48px;
-  margin-bottom: 20px;
+  margin-top: 4.8rem;
+  margin-bottom: 2rem;
   align-self: center;
 `;
 
 const RegisterTitle = styled.div`
   color: #1e1e1e;
   text-align: center;
-  font-size: 32px;
+  font-size: 3.2rem;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-  margin-bottom: 16px;
+  margin-bottom: 1.6rem;
 `;
 
 const NameInput = styled.div`
   display: flex;
-  gap: 20px;
+  gap: 2rem;
   > input {
-    width: 150px;
-    height: 40px;
-    font-size: 16px;
+    width: 15rem;
+    height: 4rem;
+    font-size: 1.6rem;
     font-weight: 400;
-    line-height: 160%; /* 25.6px */
-    letter-spacing: 0.64px;
-    border-radius: 2px;
-    border: 1px solid #404040;
+    line-height: 160%; /* 2.56rem */
+    letter-spacing: 0.064rem;
+    border-radius: 0.2rem;
+    border: 0.1rem solid #404040;
     background: #fff;
-    padding: 7px 12px;
+    padding: 0.7rem 1.2rem;
     &::placeholder {
       color: #d9d9d9;
     }
@@ -212,38 +212,38 @@ const NameInput = styled.div`
 `;
 
 const RegisterLabel = styled.div`
-  margin-top: 16px;
-  margin-bottom: 6px;
+  margin-top: 1.6rem;
+  margin-bottom: 0.6rem;
   color: #404040;
-  font-size: 20px;
+  font-size: 2rem;
   font-weight: 400;
-  line-height: 160%; /* 32px */
-  letter-spacing: 0.8px;
+  line-height: 160%; /* 3.2rem */
+  letter-spacing: 0.08rem;
 `;
 const RegisterInput = styled.input`
-  width: 320px;
-  height: 40px;
-  font-size: 16px;
+  width: 32rem;
+  height: 4rem;
+  font-size: 1.6rem;
   font-weight: 400;
-  line-height: 160%; /* 25.6px */
-  letter-spacing: 0.64px;
-  border-radius: 2px;
-  border: 1px solid #404040;
+  line-height: 160%; /* 2.56rem */
+  letter-spacing: 0.064rem;
+  border-radius: 0.2rem;
+  border: 0.1rem solid #404040;
   background: #fff;
-  padding: 7px 12px;
+  padding: 0.7rem 1.2rem;
   &::placeholder {
     color: #d9d9d9;
   }
 `;
 const RegisterCaution = styled.div`
-  margin-top: 17px;
+  margin-top: 1.7rem;
   color: #969696;
-  font-size: 10px;
+  font-size: 1rem;
   font-weight: 400;
-  line-height: 160%; /* 16px */
-  letter-spacing: 0.4px;
+  line-height: 160%; /* 1.6rem */
+  letter-spacing: 0.04rem;
   align-self: center;
-  margin-bottom: 103px;
+  margin-bottom: 10.3rem;
 `;
 
 const RegisterSubmit = styled.input<{
@@ -256,15 +256,15 @@ const RegisterSubmit = styled.input<{
   border: none;
   background: ${(props) => (props.$active ? "#F0745F" : "#d9d9d9")};
   display: flex;
-  height: 68px;
+  height: 6.8rem;
   justify-content: center;
   align-items: center;
   color: white;
   color: #fff;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 600;
-  letter-spacing: 0.9px;
-  border-bottom-left-radius: 20px;
-  border-bottom-right-radius: 20px;
+  letter-spacing: 0.09rem;
+  border-bottom-left-radius: 2rem;
+  border-bottom-right-radius: 2rem;
   cursor: pointer;
 `;


### PR DESCRIPTION
## 요약
디자이너 요구사항에 유연하게 대처할 수 있도록 스타일링에 사용되는 단위들을 상대 단위인 `rem` 으로 수정합니다.

## 변경 내역
- 대부분 px 단위들을 rem 으로 수정
  - 소수점 이슈가 없도록 1rem = 10px 로 작업하였습니다.
  - 스크롤 이벤트를 다루는 몇몇 특수한 코드 제외
  - 디자이너가 헤더의 크기는 유지하길 원했으므로 `Header.tsx` 도 제외
- 헤더 제외 전체 레이아웃을 90% 크기로 축소 (즉, 1rem = 9px로 변경)

## 체크리스트
- [x] pre-commit 통과
- [x] PR Assignees 추가
- [x] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
