### PR TITLE
♻️ 헤더 내부 API 로직, 쿠키 관련 로직을 서로 분리

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -4,6 +4,7 @@ import { getRequest } from "./utility";
 
 const SSO_COOKIE_KEY = "waffle.access-token";
 
+// TODO: checkAuth 빼고 추후 모두 삭제 필요
 export const getSsoToken = (): string | null => {
   //로컬 환경에서는 환경변수로 지정한 토큰 사용
   const externalToken = import.meta.env.VITE_EXTERNAL_AUTH_TOKEN;
@@ -22,6 +23,7 @@ export const tryLogin = (recruit_id: number | "home") => {
   location.href = `${SSO_LOGIN_URL}/?redirect_uri=${SSO_REDIRECT_URL}/${recruit_id}`;
 };
 
+// DESCRIPTION: 유일하게 API인 부분이므로 남겨둠.
 export const checkAuth = (): Promise<"invalid" | "valid" | "need_register"> =>
   getRequest<{ signup: boolean }>("/v1/users/check").then(
     (res) => (res.signup ? ("valid" as const) : ("need_register" as const)),

--- a/src/components/home/Header/HeaderV2.tsx
+++ b/src/components/home/Header/HeaderV2.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { checkAuth, deleteSsoToken, tryLogin } from "../../../apis/auth";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouteNavigation } from "../../../shared/routes/useRouteNavigation";
+
+export default function Headerv2() {
+  const { toHomeV2, toAnnouncement, toRecruitingList } = useRouteNavigation();
+  const queryClient = useQueryClient();
+
+  const { data: authState } = useQuery({
+    queryKey: ["auth"],
+    queryFn: () => checkAuth(),
+    staleTime: 1000 * 60 * 60,
+    retry: 0,
+  });
+
+  if (!authState) {
+    return (
+      <div>
+        <button onClick={toHomeV2}>
+          <img src={"/icon/header/Logo.jpeg"} height={27} />
+        </button>
+        <span>로그인 정보 확인 중...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button onClick={toHomeV2}>
+        <img src={"/icon/header/Logo.jpeg"} height={27} />
+      </button>
+      <div>
+        {authState === "valid" ? (
+          <button
+            onClick={() => {
+              deleteSsoToken();
+              queryClient.invalidateQueries(["auth"]);
+              toHomeV2();
+            }}
+          >
+            <img src={"/icon/header/Logout.svg"} />
+            로그아웃
+          </button>
+        ) : (
+          <button
+            onClick={() => {
+              tryLogin("home");
+            }}
+          >
+            <img src={"/icon/header/Login.svg"} />
+            로그인
+          </button>
+        )}
+        <button onClick={toRecruitingList}>
+          <img src={"/icon/header/Apply.svg"} />
+          지원페이지
+        </button>
+        <button onClick={toAnnouncement}>
+          <img src={"/icon/header/Alarm.svg"} />
+          공지사항
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/Header/HeaderV2.tsx
+++ b/src/components/home/Header/HeaderV2.tsx
@@ -1,18 +1,14 @@
-import { useQuery } from "@tanstack/react-query";
-import { checkAuth, deleteSsoToken, tryLogin } from "../../../apis/auth";
-import { useQueryClient } from "@tanstack/react-query";
+import { getSsoUtils } from "../../../entities/lib/sso";
+import { useAuthQuery } from "../../../entities/auth/useAuthQuery";
 import { useRouteNavigation } from "../../../shared/routes/useRouteNavigation";
 
 export default function Headerv2() {
   const { toHomeV2, toAnnouncement, toRecruitingList } = useRouteNavigation();
-  const queryClient = useQueryClient();
+  const { useCheckAuth, useLogout } = useAuthQuery();
+  const { tryLogin } = getSsoUtils();
 
-  const { data: authState } = useQuery({
-    queryKey: ["auth"],
-    queryFn: () => checkAuth(),
-    staleTime: 1000 * 60 * 60,
-    retry: 0,
-  });
+  const { data: authState } = useCheckAuth();
+  const { mutation: tryLogout } = useLogout();
 
   if (!authState) {
     return (
@@ -20,7 +16,6 @@ export default function Headerv2() {
         <button onClick={toHomeV2}>
           <img src={"/icon/header/Logo.jpeg"} height={27} />
         </button>
-        <span>로그인 정보 확인 중...</span>
       </div>
     );
   }
@@ -34,8 +29,7 @@ export default function Headerv2() {
         {authState === "valid" ? (
           <button
             onClick={() => {
-              deleteSsoToken();
-              queryClient.invalidateQueries(["auth"]);
+              tryLogout();
               toHomeV2();
             }}
           >

--- a/src/entities/auth/useAuthQuery.ts
+++ b/src/entities/auth/useAuthQuery.ts
@@ -1,0 +1,29 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { checkAuth } from "../../apis/auth";
+import { getSsoUtils } from "../lib/sso";
+
+export const useAuthQuery = () => {
+  const queryClient = useQueryClient();
+
+  const { deleteSsoToken } = getSsoUtils();
+  return {
+    useCheckAuth: () => {
+      const { data } = useQuery({
+        queryKey: ["auth"],
+        queryFn: () => checkAuth(),
+        staleTime: 1000 * 60 * 60,
+        retry: 0,
+      });
+
+      return { data };
+    },
+    useLogout: () => {
+      return {
+        mutation: () => {
+          deleteSsoToken();
+          queryClient.invalidateQueries(["auth"]);
+        },
+      };
+    },
+  };
+};

--- a/src/entities/lib/cookie.ts
+++ b/src/entities/lib/cookie.ts
@@ -1,0 +1,23 @@
+import Cookies from "js-cookie";
+
+export const getCookieUtils = () => {
+  return {
+    getCookie: ({ key }: { key: string }) => {
+      return Cookies.get(key);
+    },
+    removeCookie: ({
+      key,
+      path,
+      domain,
+    }: {
+      key: string;
+      path: string;
+      domain: string;
+    }) => {
+      Cookies.remove(key, {
+        path,
+        domain,
+      });
+    },
+  };
+};

--- a/src/entities/lib/sso.ts
+++ b/src/entities/lib/sso.ts
@@ -1,0 +1,29 @@
+import { SSO_LOGIN_URL, SSO_REDIRECT_URL } from "../../apis/environment";
+import { getCookieUtils } from "./cookie";
+
+const SSO_COOKIE_KEY = "waffle.access-token";
+
+export const getSsoUtils = () => {
+  const { getCookie, removeCookie } = getCookieUtils();
+  return {
+    getSsoToken: (): string | null => {
+      //로컬 환경에서는 환경변수로 지정한 토큰 사용
+      const externalToken = import.meta.env.VITE_EXTERNAL_AUTH_TOKEN;
+      if (externalToken) return externalToken;
+
+      //쿠키에 저장된 토큰 사용
+      const token = getCookie({ key: SSO_COOKIE_KEY });
+      return token ?? null;
+    },
+    deleteSsoToken: () => {
+      removeCookie({
+        key: SSO_COOKIE_KEY,
+        path: "/",
+        domain: ".wafflestudio.com",
+      });
+    },
+    tryLogin: (recruit_id: number | "home") => {
+      location.href = `${SSO_LOGIN_URL}/?redirect_uri=${SSO_REDIRECT_URL}/${recruit_id}`;
+    },
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import initMocks from "./mocks/index";
+import { PATH } from "./shared/routes/constants";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import GlobalStyles from "./GlobalStyles";
@@ -17,8 +18,11 @@ import { resumeLoader } from "./pages/Loader/ResumeLoader";
 import Result, { NoResult } from "./pages/Result";
 import { resultLoader } from "./pages/Loader/ResultLoader";
 import RecruitList from "./pages/RecruitList";
+import HomeV2 from "./pages/HomeV2";
 
 const queryClient = new QueryClient();
+
+const { HOME_V2, ANNOUNCEMENT, RECRUITING_LIST } = PATH;
 
 const router = createBrowserRouter([
   {
@@ -28,7 +32,13 @@ const router = createBrowserRouter([
     index: true,
   },
   {
-    path: "recruiting",
+    path: HOME_V2,
+    element: <HomeV2 />,
+    errorElement: <div>error</div>,
+    index: true,
+  },
+  {
+    path: RECRUITING_LIST,
     element: <RecruitList />,
     errorElement: <div>error</div>,
   },
@@ -58,7 +68,7 @@ const router = createBrowserRouter([
       },
     ],
   },
-  { path: "announcement", element: <Announcement /> },
+  { path: ANNOUNCEMENT, element: <Announcement /> },
   { path: "/sso/:recruit_id", element: <Sso /> },
 ]);
 

--- a/src/pages/HomeV2.tsx
+++ b/src/pages/HomeV2.tsx
@@ -1,0 +1,15 @@
+import Headerv2 from "../components/home/Header/HeaderV2";
+import styled from "styled-components";
+
+export default function HomeV2() {
+  return (
+    <>
+      <Headerv2 />
+      <MainContainer></MainContainer>
+    </>
+  );
+}
+
+const MainContainer = styled.main`
+  minwidth: "92.0rem";
+`;

--- a/src/shared/routes/constants.ts
+++ b/src/shared/routes/constants.ts
@@ -1,0 +1,5 @@
+export const PATH = {
+  HOME_V2: "v2",
+  RECRUITING_LIST: "/recruiting",
+  ANNOUNCEMENT: "/announcement",
+};

--- a/src/shared/routes/constants.ts
+++ b/src/shared/routes/constants.ts
@@ -1,5 +1,5 @@
 export const PATH = {
-  HOME_V2: "v2",
+  HOME_V2: "/v2",
   RECRUITING_LIST: "/recruiting",
   ANNOUNCEMENT: "/announcement",
 };

--- a/src/shared/routes/useRouteNavigation.ts
+++ b/src/shared/routes/useRouteNavigation.ts
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import { PATH } from "./constants";
+
+export const useRouteNavigation = () => {
+  const navigation = useNavigate();
+  const { HOME_V2, ANNOUNCEMENT, RECRUITING_LIST } = PATH;
+
+  return {
+    toHomeV2: () => {
+      void navigation(HOME_V2);
+    },
+    toAnnouncement: () => {
+      void navigation(ANNOUNCEMENT);
+    },
+    toRecruitingList: () => {
+      void navigation(RECRUITING_LIST);
+    },
+  };
+};


### PR DESCRIPTION
## 요약
헤더에서 api와 종속되어 있던 navigation 로직, api 로직, 쿠키 로직, 쿼리 무효화 로직을 분리하여 관리하도록 수정하였습니다.

## 변경 내역
- 기존에는 navigation을 직접 import하여 사용하였으나 현재는 shared/routes/useRouteNavigation에서 관리합니다.
- auth API 로직과 tanstack query 로직이 view 단에서 모두 결합되어 있습니다. api 로직 이후 tanstack query를 감싼 버전을 view 단에서 사용하도록 수정하였습니다.
(apis/auth -> entities/auth/useAuthQuery -> 이를 헤더에서 사용)
- auth API 로직 중 api와 함께 관리되기에는 조금 애매한 쿠키 관련 로직들을 모두 별도의 로직으로 분리하였습니다. auth 관련 api를 사용하고 있는 다른 부분들이 많은 관계로 전체적인 변경은 관련 API에 대한 모든 테스팅 이후 새로운 PR을 올리도록 하겠습니다.

## 체크리스트
- [x] pre-commit 통과
- [x] PR Assignees 추가
- [x] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
