### PR TITLE
✨ husky 사용 시 pre-commit 단계 빌드 제거 및 pre-push 단계 타입 체크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@
 ```shell
 yarn
 husky install # 허스키(pre-commit library) 설치
-husky add .husky/pre-commit "lint-staged --no-stash --verbose && yarn typecheck" # 허스키 명령어 세팅
+husky add .husky/pre-commit "lint-staged --no-stash --verbose" # 허스키 명령어 세팅
+husky add .husky/pre-push "typecheck"
 
 ```
 
-- 윈도우의 경우 "yarn lint-staged --no-stash --verbose && yarn typecheck"를 사용
+- 윈도우의 경우
+
+```shell
+yarn
+yarn husky install # 허스키(pre-commit library) 설치
+yarn husky add .husky/pre-commit "yarn lint-staged --no-stash --verbose" # 허스키 명령어 세팅
+yarn husky add .husky/pre-push "yarn typecheck"
+
+```
 
 ## 테스트 서버 실행
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 ## 와플스튜디오 리크루팅 페이지 리뉴얼
 
-
-
 # Table of Content
+
 - [Usage](#Usage)
 
 # Usage
+
 ## 개발 환경 세팅
+
 ```shell
 yarn
 husky install # 허스키(pre-commit library) 설치
-husky add .husky/pre-commit "lint-staged --no-stash --verbose && yarn build" # 허스키 명령어 세팅
+husky add .husky/pre-commit "lint-staged --no-stash --verbose && yarn typecheck" # 허스키 명령어 세팅
 
 ```
-- 윈도우의 경우 "yarn lint-staged --no-stash --verbose && yarn build"를 사용
+
+- 윈도우의 경우 "yarn lint-staged --no-stash --verbose && yarn typecheck"를 사용
 
 ## 테스트 서버 실행
 
@@ -24,9 +26,7 @@ yarn dev
 ```
 
 ## 빌드
+
 ```shell
 yarn build
 ```
-
-
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "lint-staged": {


### PR DESCRIPTION
## 요약
기존에는 매 커밋마다 빌드를 수행했으나, 이제는 타입 체크 로직만 돌아가도록 수정하였습니다.

## 변경 내역
매 커밋마다 빌드를 수행하는 것 대신 lint, prettier는 커밋마다, 타입체크는 push 시에 돌아가도록 수정하였습니다.

## 체크리스트
- [x] pre-commit 통과
- [x] PR Assignees 추가
- [x] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
