### PR TITLE
✨ 프로그래머스 지원 관련 설명 페이지 생성

### DIFF
--- a/src/components/programmer/ProgrammerRecruitInfo.tsx
+++ b/src/components/programmer/ProgrammerRecruitInfo.tsx
@@ -2,6 +2,39 @@ import styled from "styled-components";
 import { MAILTO_RECRUIT } from "../../common/const";
 
 export const ProgrammerRecruitInfo = () => {
+  const requirements = [
+    {
+      contents: "이름, 학교, 학과, 학번",
+    },
+    {
+      contents: "전화번호",
+      detail: "예. 010-1234-5678",
+    },
+    {
+      contents: "슬랙, 노션, 깃허브 초대를 위한 이메일",
+      detail: (
+        <>
+          세 가지에 대해 모두 작성해주세요. (예. 깃허브
+          example_github@gmail.com, 슬랙/노션 example_slack@naver.com)
+        </>
+      ),
+    },
+    {
+      contents: "지원하는 포지션 및 주 사용 기술스택",
+      detail: "복수 응답 또한 가능합니다. (예. Frontent / React, Next.js)",
+    },
+    {
+      contents: (
+        <>
+          지원 동기 <Highlight>(500자 내외)</Highlight>
+        </>
+      ),
+    },
+    {
+      contents: "프로젝트 진행과 관련한 자료 및 간략한 설명",
+      detail: "예. 깃허브 링크, 포트폴리오 등",
+    },
+  ];
   return (
     <div>
       <div>
@@ -13,36 +46,12 @@ export const ProgrammerRecruitInfo = () => {
           </Description>
 
           <RequirementsList style={{ counterReset: "item" }}>
-            <RequirementItem>
-              <RequirementText>이름, 학교, 학과, 학번</RequirementText>
-            </RequirementItem>
-
-            <RequirementItem>
-              <RequirementText>전화번호 및 연락을 위한 이메일</RequirementText>
-            </RequirementItem>
-
-            <RequirementItem>
-              <RequirementText>
-                슬랙, 노션, 깃허브 초대를 위한 이메일
-              </RequirementText>
-              <SubText>
-                세 가지에 대해 모두 작성해주세요. (예. 깃허브
-                example_github@gmail.com, 슬랙/노션 example_slack@naver.com)
-              </SubText>
-            </RequirementItem>
-
-            <RequirementItem>
-              <RequirementText>
-                지원 동기 <Highlight>(500자 내외)</Highlight>
-              </RequirementText>
-            </RequirementItem>
-
-            <RequirementItem>
-              <RequirementText>
-                프로젝트 진행과 관련한 자료 및 간략한 설명
-              </RequirementText>
-              <SubText>(예. 깃허브 링크, 포트폴리오 등)</SubText>
-            </RequirementItem>
+            {requirements.map(({ contents, detail }) => (
+              <RequirementItem>
+                <RequirementText>{contents}</RequirementText>
+                {detail !== undefined && <SubText>{detail}</SubText>}
+              </RequirementItem>
+            ))}
           </RequirementsList>
         </Content>
       </div>

--- a/src/components/programmer/ProgrammerRecruitInfo.tsx
+++ b/src/components/programmer/ProgrammerRecruitInfo.tsx
@@ -1,0 +1,128 @@
+import styled from "styled-components";
+import { MAILTO_RECRUIT } from "../../common/const";
+
+export const ProgrammerRecruitInfo = () => {
+  return (
+    <div>
+      <div>
+        <Content>
+          <Description>
+            <Email href={MAILTO_RECRUIT}>recruit@wafflestudio.com</Email>으로
+            아래 내용을 보내주시면 <Highlight>7일 이내로</Highlight> 비대면
+            인터뷰 날짜를 잡아드릴 예정입니다.
+          </Description>
+
+          <RequirementsList style={{ counterReset: "item" }}>
+            <RequirementItem>
+              <RequirementText>이름, 학교, 학과, 학번</RequirementText>
+            </RequirementItem>
+
+            <RequirementItem>
+              <RequirementText>전화번호 및 연락을 위한 이메일</RequirementText>
+            </RequirementItem>
+
+            <RequirementItem>
+              <RequirementText>
+                슬랙, 노션, 깃허브 초대를 위한 이메일
+              </RequirementText>
+              <SubText>
+                세 가지에 대해 모두 작성해주세요. (예. 깃허브
+                example_github@gmail.com, 슬랙/노션 example_slack@naver.com)
+              </SubText>
+            </RequirementItem>
+
+            <RequirementItem>
+              <RequirementText>
+                지원 동기 <Highlight>(500자 내외)</Highlight>
+              </RequirementText>
+            </RequirementItem>
+
+            <RequirementItem>
+              <RequirementText>
+                프로젝트 진행과 관련한 자료 및 간략한 설명
+              </RequirementText>
+              <SubText>(예. 깃허브 링크, 포트폴리오 등)</SubText>
+            </RequirementItem>
+          </RequirementsList>
+        </Content>
+      </div>
+    </div>
+  );
+};
+
+const Content = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 3rem;
+`;
+
+const Description = styled.p`
+  font-size: 16px;
+  color: ${({ theme }) => theme.colors.black[800]};
+  padding: 2rem;
+  background: ${({ theme }) => theme.colors.black[100]};
+  border-left: 4px solid ${({ theme }) => theme.colors.oak};
+  border-radius: 0.8rem;
+`;
+
+const Email = styled.a`
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
+const RequirementsList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  list-style: none;
+`;
+
+const RequirementItem = styled.li`
+  padding: 2rem;
+  border: 0.2rem solid ${({ theme }) => theme.colors.black[100]};
+  border-radius: 1.2rem;
+  transition: all 0.3s ease;
+  position: relative;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.black[300]};
+    box-shadow: 0 5px 15px rgba(79, 172, 254, 0.1);
+    transform: translateY(-2px);
+  }
+
+  &::before {
+    content: counter(item);
+    counter-increment: item;
+    position: absolute;
+    left: -1rem;
+    top: -1rem;
+    width: 2.8rem;
+    height: 2.8rem;
+    background: ${({ theme }) => theme.colors.black[700]};
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: ${({ theme }) => theme.fontWeights.bold};
+    font-size: ${({ theme }) => theme.fontSizes[14]};
+  }
+`;
+
+const RequirementText = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes[16]};
+  color: ${({ theme }) => theme.colors.black[900]};
+`;
+
+const SubText = styled.div`
+  font-size: ${({ theme }) => theme.fontSizes[14]};
+  color: ${({ theme }) => theme.colors.black[700]};
+  margin-top: 1rem;
+  font-style: italic;
+`;
+
+const Highlight = styled.span`
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+`;

--- a/src/components/programmer/ProgrammerRecruitInfo.tsx
+++ b/src/components/programmer/ProgrammerRecruitInfo.tsx
@@ -21,7 +21,7 @@ export const ProgrammerRecruitInfo = () => {
     },
     {
       contents: "지원하는 포지션 및 주 사용 기술스택",
-      detail: "복수 응답 또한 가능합니다. (예. Frontent / React, Next.js)",
+      detail: "복수 응답 또한 가능합니다. (예. 웹 프론트엔드 / React, Next.js)",
     },
     {
       contents: (

--- a/src/components/rookie/Progress/ProgressList.tsx
+++ b/src/components/rookie/Progress/ProgressList.tsx
@@ -7,6 +7,7 @@ import PortfolioCard from "./PortfolioCard";
 import { ResumeCard } from "./ResumeCard";
 import PortfolioCard from "./PortfolioCard";
 // import PortfolioCard from "./PortfolioCard";
+import { ProgrammerRecruitInfo } from "../../programmer/ProgrammerRecruitInfo";
 
 type ProgressListProps = {
   recruiting: Recruiting;
@@ -14,21 +15,21 @@ type ProgressListProps = {
   type: number;
 };
 
-export function ProgressList({
+function ResumeInfo({
+  recruitingType,
   recruiting,
   hasResume,
-  type,
-}: ProgressListProps) {
-  const problems = recruiting.problem_status;
-
-  return (
-    <List>
-      <ResumeCard submit={hasResume} />
-      {/* 루키가 아니면 코딩테스트 대신 포트폴리오 제출 필요 */}
-      {type !== RecruitingType.ROOKIE ? (
-        <PortfolioCard recruiting={recruiting} />
-      ) : (
-        problems
+}: {
+  recruitingType: number;
+  recruiting: Recruiting;
+  hasResume: boolean;
+}) {
+  if (recruitingType === RecruitingType.ROOKIE) {
+    const problems = recruiting.problem_status;
+    return (
+      <>
+        <ResumeCard submit={hasResume} />
+        {problems
           .sort((a, b) => {
             if (a.num > b.num) return 1;
             if (a.num < b.num) return -1;
@@ -41,8 +42,34 @@ export function ProgressList({
               statusCode={status}
               to={`./solve/${id}`}
             />
-          ))
-      )}
+          ))}
+      </>
+    );
+  }
+  if (recruitingType === RecruitingType.PROGRAMMER) {
+    return <ProgrammerRecruitInfo />;
+  }
+  return (
+    <>
+      <ResumeCard submit={hasResume} />
+      <PortfolioCard recruiting={recruiting} />
+    </>
+  );
+}
+
+export function ProgressList({
+  recruiting,
+  hasResume,
+  type,
+}: ProgressListProps) {
+  return (
+    <List>
+      {/* 루키가 아니면 코딩테스트 대신 포트폴리오 제출 필요 */}
+      <ResumeInfo
+        recruiting={recruiting}
+        recruitingType={type}
+        hasResume={hasResume}
+      />
     </List>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,8 +20,8 @@ import { resumeLoader } from "./pages/Loader/ResumeLoader";
 import Result, { NoResult } from "./pages/Result";
 import { resultLoader } from "./pages/Loader/ResultLoader";
 import RecruitList from "./pages/RecruitList";
-import Project from "./pages/Project";
-import ProjectDetail from "./pages/ProjectDetail";
+import ProjectV2 from "./pages/ProjectV2";
+import ProjectDetailV2 from "./pages/ProjectDetailV2";
 import Review from "./pages/Review";
 import Member from "./pages/Member";
 import HomeV2 from "./pages/HomeV2";
@@ -65,12 +65,12 @@ const router = createBrowserRouter([
   },
   {
     path: PROJECT_LIST,
-    element: <Project />,
+    element: <ProjectV2 />,
     errorElement: <div>error</div>,
   },
   {
     path: PROJECT_DETAIL,
-    element: <ProjectDetail />,
+    element: <ProjectDetailV2 />,
     errorElement: <div>error</div>,
   },
   {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   recruitingDetailQuery,
 } from "./Loader/DashboardLoader.ts";
 import { applyRecruiting, cancelRecruiting } from "../apis/recruiting.ts";
+import { RecruitingType } from "../types/apiTypes.ts";
 
 export default function Dashboard() {
   const queryClient = useQueryClient();
@@ -64,40 +65,43 @@ export default function Dashboard() {
             />
           </div>
         </AnnouncementButton> */}
-        {initialData.recruiting.applied ? (
-          <AnnouncementButton onClick={() => navigate("./result")}>
-            지원 결과 확인하기
-            <div>
-              <img
-                src="/icon/rookie/AnnounceRightArrow.svg"
-                alt="&rarr;"
-                width={20}
-              />
-              <img
-                src="/icon/rookie/AnnounceRightArrowWhite.svg"
-                alt="&rarr;"
-                width={20}
-              />
-            </div>
-          </AnnouncementButton>
-        ) : (
-          <AnnouncementButton
-            onClick={() =>
-              applyRecruiting(recruiting.id)
-                .then(() => {
-                  alert("지원이 완료되었습니다.");
-                  navigate(0);
-                })
-                .catch((res: Response) => {
-                  res.json().then((data) => {
-                    alert(data.detail);
-                  });
-                })
-            }
-          >
-            지원하기
-          </AnnouncementButton>
-        )}
+        {initialData.recruiting.applied &&
+          recruiting.type !== RecruitingType.PROGRAMMER && (
+            <AnnouncementButton onClick={() => navigate("./result")}>
+              지원 결과 확인하기
+              <div>
+                <img
+                  src="/icon/rookie/AnnounceRightArrow.svg"
+                  alt="&rarr;"
+                  width={20}
+                />
+                <img
+                  src="/icon/rookie/AnnounceRightArrowWhite.svg"
+                  alt="&rarr;"
+                  width={20}
+                />
+              </div>
+            </AnnouncementButton>
+          )}{" "}
+        {!initialData.recruiting.applied &&
+          recruiting.type !== RecruitingType.PROGRAMMER && (
+            <AnnouncementButton
+              onClick={() =>
+                applyRecruiting(recruiting.id)
+                  .then(() => {
+                    alert("지원이 완료되었습니다.");
+                    navigate(0);
+                  })
+                  .catch((res: Response) => {
+                    res.json().then((data) => {
+                      alert(data.detail);
+                    });
+                  })
+              }
+            >
+              지원하기
+            </AnnouncementButton>
+          )}
         <BottomContainer>
           <ProgressList
             recruiting={recruiting}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -108,37 +108,39 @@ export default function Dashboard() {
             hasResume={resume.items.length > 0}
             type={recruiting.type}
           />
-          <Caution>
-            위 내용은 제출 후에도 상시 수정할 수 있으며, 모두 제출해야 지원
-            완료됩니다.
-            {initialData.recruiting.applied ? (
-              <CancelButton
-                onClick={() => {
-                  if (
-                    confirm(
-                      "지원을 취소하면 입력한 자기소개서와 문제의 제출 내역이 모두 삭제됩니다. 정말로 지원을 취소하시겠습니까?",
-                    )
-                  ) {
-                    cancelRecruiting(recruiting.id)
-                      .then(() => {
-                        queryClient.invalidateQueries(["recruiting"]);
-                        queryClient.invalidateQueries(["resume"]);
-                        queryClient.invalidateQueries(["user"]);
-                        alert("지원이 취소되었습니다");
-                        navigate("/");
-                      })
-                      .catch((res: Response) => {
-                        res.json().then((data) => {
-                          alert(data.detail);
+          {recruiting.type !== RecruitingType.PROGRAMMER && (
+            <Caution>
+              위 내용은 제출 후에도 상시 수정할 수 있으며, 모두 제출해야 지원
+              완료됩니다.
+              {initialData.recruiting.applied ? (
+                <CancelButton
+                  onClick={() => {
+                    if (
+                      confirm(
+                        "지원을 취소하면 입력한 자기소개서와 문제의 제출 내역이 모두 삭제됩니다. 정말로 지원을 취소하시겠습니까?",
+                      )
+                    ) {
+                      cancelRecruiting(recruiting.id)
+                        .then(() => {
+                          queryClient.invalidateQueries(["recruiting"]);
+                          queryClient.invalidateQueries(["resume"]);
+                          queryClient.invalidateQueries(["user"]);
+                          alert("지원이 취소되었습니다");
+                          navigate("/");
+                        })
+                        .catch((res: Response) => {
+                          res.json().then((data) => {
+                            alert(data.detail);
+                          });
                         });
-                      });
-                  }
-                }}
-              >
-                지원 취소
-              </CancelButton>
-            ) : null}
-          </Caution>
+                    }
+                  }}
+                >
+                  지원 취소
+                </CancelButton>
+              ) : null}
+            </Caution>
+          )}
         </BottomContainer>
       </Main>
     </>

--- a/src/pages/ProjectDetailV2.tsx
+++ b/src/pages/ProjectDetailV2.tsx
@@ -69,7 +69,7 @@ const ArrowButton = styled.button<{ left?: boolean }>`
   }
 `;
 
-export default function ProjectDetailPage() {
+export default function ProjectDetailPageV2() {
   const [index, setIndex] = useState(0);
   const project = projectDetail;
 

--- a/src/pages/ProjectV2.tsx
+++ b/src/pages/ProjectV2.tsx
@@ -107,7 +107,7 @@ const Description = styled.p`
   color: #4b5563;
 `;
 
-export default function ProjectGrid() {
+export default function ProjectV2() {
   const { toProjectDetail } = useRouteNavigation();
   const [selectedType, setSelectedType] = useState<"SERVICE" | "STUDY">(
     "SERVICE",


### PR DESCRIPTION
## 요약

프로그래머스 지원 관련 설명 페이지를 새롭게 추가하였습니다.

## 변경 내역

- 프로그래머스 지원은 메일로만 수행할 수 있도록 합니다.
- 메일 작성에 필요한 내용을 명시하였습니다.
<img width="852" height="792" alt="image (1)" src="https://github.com/user-attachments/assets/270ec7da-96ee-4af1-bbf0-7a218fbff7e6" />


## 체크리스트

- [x] pre-commit 통과
- [x] PR Assignees 추가
- [x] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
