### PR TITLE
💄 와플 히스토리 박스 드랍/바운스 모션 개선

### DIFF
--- a/src/features/home/ui/WaffleHistory.tsx
+++ b/src/features/home/ui/WaffleHistory.tsx
@@ -303,7 +303,6 @@ const StatCardGray = styled.div<{ $isVisible: boolean }>`
   --tilt: 0deg;
   opacity: 0;
   ${dropAnimation("1.0s", "0s")}
-  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 196.608px;
@@ -314,6 +313,8 @@ const StatCardGray = styled.div<{ $isVisible: boolean }>`
     height: 146.196px;
     ${dropAnimation("1.0s", "0.1s")}
   }
+
+  ${reducedMotion}
 `;
 
 const StatLabel = styled.div`
@@ -448,7 +449,6 @@ const StatCardBlue = styled.div<{ $isVisible: boolean }>`
   --tilt: -12.342deg;
   opacity: 0;
   ${dropAnimation("1.2s", "0.2s")}
-  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 342.804px;
@@ -460,6 +460,8 @@ const StatCardBlue = styled.div<{ $isVisible: boolean }>`
     --tilt: 0deg;
     ${dropAnimation("1.2s", "0.2s")}
   }
+
+  ${reducedMotion}
 `;
 
 const StatCardGreen = styled.div<{ $isVisible: boolean }>`
@@ -478,7 +480,6 @@ const StatCardGreen = styled.div<{ $isVisible: boolean }>`
   --tilt: 16.315deg;
   opacity: 0;
   ${dropAnimation("1.3s", "0.3s")}
-  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 575px;
@@ -490,6 +491,8 @@ const StatCardGreen = styled.div<{ $isVisible: boolean }>`
     --tilt: 13.811deg;
     ${dropAnimation("1.3s", "0.3s")}
   }
+
+  ${reducedMotion}
 `;
 
 const StatCardBrown = styled.div<{ $isVisible: boolean }>`
@@ -508,7 +511,6 @@ const StatCardBrown = styled.div<{ $isVisible: boolean }>`
   --tilt: 0deg;
   opacity: 0;
   ${dropAnimation("1.1s", "0.1s")}
-  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 0;
@@ -519,4 +521,6 @@ const StatCardBrown = styled.div<{ $isVisible: boolean }>`
     height: 196.608px;
     ${dropAnimation("1.1s", "0s")}
   }
+
+  ${reducedMotion}
 `;

--- a/src/features/home/ui/WaffleHistory.tsx
+++ b/src/features/home/ui/WaffleHistory.tsx
@@ -1,6 +1,81 @@
-import styled from "styled-components";
+import styled, { css, keyframes } from "styled-components";
 import { useHistoryQuery } from "../../../apis/history/history.query";
 import { useEffect, useRef, useState } from "react";
+
+const FALL = "cubic-bezier(0.45, 0, 1, 1)";
+const RISE = "cubic-bezier(0, 0, 0.35, 1)";
+
+const dropBounce = keyframes`
+  0% {
+    opacity: 1;
+    transform: translateY(var(--drop-from, -180%)) rotate(var(--tilt, 0deg))
+      scaleX(0.97) scaleY(1.05);
+    animation-timing-function: ${FALL};
+  }
+  36% {
+    transform: translateY(0) rotate(var(--tilt, 0deg)) scaleX(0.99) scaleY(1.02);
+    animation-timing-function: ${FALL};
+  }
+  40% {
+    /* 1차 착지: 바닥을 향해 눌림 */
+    transform: translateY(0) rotate(var(--tilt, 0deg)) scaleX(1.07) scaleY(0.9);
+    animation-timing-function: ${RISE};
+  }
+  45% {
+    transform: translateY(0) rotate(var(--tilt, 0deg)) scaleX(1) scaleY(1);
+    animation-timing-function: ${RISE};
+  }
+  57% {
+    transform: translateY(-12%) rotate(var(--tilt, 0deg));
+    animation-timing-function: ${FALL};
+  }
+  66% {
+    /* 2차 착지: 약한 눌림 */
+    transform: translateY(0) rotate(var(--tilt, 0deg)) scaleX(1.04) scaleY(0.94);
+    animation-timing-function: ${RISE};
+  }
+  70% {
+    transform: translateY(0) rotate(var(--tilt, 0deg));
+    animation-timing-function: ${RISE};
+  }
+  82% {
+    transform: translateY(-5%) rotate(var(--tilt, 0deg));
+    animation-timing-function: ${FALL};
+  }
+  90% {
+    /* 3차 착지: 미세한 눌림 */
+    transform: translateY(0) rotate(var(--tilt, 0deg)) scaleX(1.02) scaleY(0.97);
+    animation-timing-function: ${RISE};
+  }
+  95% {
+    transform: translateY(-2%) rotate(var(--tilt, 0deg));
+    animation-timing-function: ${FALL};
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) rotate(var(--tilt, 0deg));
+  }
+`;
+
+const dropAnimation = (duration: string, delay: string) => css<{
+  $isVisible: boolean;
+}>`
+  animation: ${({ $isVisible }) =>
+    $isVisible
+      ? css`
+          ${dropBounce} ${duration} linear ${delay} forwards
+        `
+      : "none"};
+`;
+
+const reducedMotion = css<{ $isVisible: boolean }>`
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
+    transform: rotate(var(--tilt, 0deg));
+    transition: opacity 0.3s ease-in-out;
+  }
+`;
 
 export const WaffleHistory = () => {
   const { useGetHistories } = useHistoryQuery();
@@ -225,40 +300,10 @@ const StatCardGray = styled.div<{ $isVisible: boolean }>`
   align-items: flex-start;
   border-radius: clamp(15px, 2.83cqw, 24px);
   background: #efebeb;
+  --tilt: 0deg;
   opacity: 0;
-  animation: ${({ $isVisible }) =>
-    $isVisible
-      ? "dropWithBounce 1.0s cubic-bezier(0.25, 0.1, 0.25, 1) forwards"
-      : "none"};
-
-  @keyframes dropWithBounce {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh);
-    }
-    55% {
-      transform: translateY(0);
-    }
-    70% {
-      transform: translateY(-15px);
-    }
-    82% {
-      transform: translateY(0);
-    }
-    93% {
-      transform: translateY(-8px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: opacity 0.3s ease-in-out;
-  }
+  ${dropAnimation("1.0s", "0s")}
+  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 196.608px;
@@ -267,10 +312,7 @@ const StatCardGray = styled.div<{ $isVisible: boolean }>`
     right: unset;
     width: 64.71%;
     height: 146.196px;
-    animation: ${({ $isVisible }) =>
-      $isVisible
-        ? "dropWithBounce 1.0s cubic-bezier(0.25, 0.1, 0.25, 1) 0.1s forwards"
-        : "none"};
+    ${dropAnimation("1.0s", "0.1s")}
   }
 `;
 
@@ -403,64 +445,10 @@ const StatCardBlue = styled.div<{ $isVisible: boolean }>`
   align-items: flex-start;
   border-radius: clamp(15px, 2.83cqw, 24px);
   background: #37007f;
+  --tilt: -12.342deg;
   opacity: 0;
-  animation: ${({ $isVisible }) =>
-    $isVisible
-      ? "dropWithBounceBlue 1.2s cubic-bezier(0.25, 0.1, 0.25, 1) 0.2s forwards"
-      : "none"};
-
-  @keyframes dropWithBounceBlue {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh) rotate(-12.342deg);
-    }
-    55% {
-      transform: translateY(0) rotate(-12.342deg);
-    }
-    70% {
-      transform: translateY(-15px) rotate(-12.342deg);
-    }
-    82% {
-      transform: translateY(0) rotate(-12.342deg);
-    }
-    93% {
-      transform: translateY(-8px) rotate(-12.342deg);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0) rotate(-12.342deg);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transform: rotate(-12.342deg);
-    transition: opacity 0.3s ease-in-out;
-  }
-
-  @keyframes dropWithBounceBlueNoRotate {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh);
-    }
-    55% {
-      transform: translateY(0);
-    }
-    70% {
-      transform: translateY(-15px);
-    }
-    82% {
-      transform: translateY(0);
-    }
-    93% {
-      transform: translateY(-8px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
+  ${dropAnimation("1.2s", "0.2s")}
+  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 342.804px;
@@ -469,14 +457,8 @@ const StatCardBlue = styled.div<{ $isVisible: boolean }>`
     left: unset;
     width: 67.81%;
     height: 210.967px;
-    animation: ${({ $isVisible }) =>
-      $isVisible
-        ? "dropWithBounceBlueNoRotate 1.2s cubic-bezier(0.25, 0.1, 0.25, 1) 0.2s forwards"
-        : "none"};
-  }
-
-  @media (max-width: 767px) and (prefers-reduced-motion: reduce) {
-    transform: none;
+    --tilt: 0deg;
+    ${dropAnimation("1.2s", "0.2s")}
   }
 `;
 
@@ -493,64 +475,10 @@ const StatCardGreen = styled.div<{ $isVisible: boolean }>`
   align-items: flex-start;
   border-radius: clamp(15px, 2.83cqw, 24px);
   background: #00cd48;
+  --tilt: 16.315deg;
   opacity: 0;
-  animation: ${({ $isVisible }) =>
-    $isVisible
-      ? "dropWithBounceGreen 1.3s cubic-bezier(0.25, 0.1, 0.25, 1) 0.3s forwards"
-      : "none"};
-
-  @keyframes dropWithBounceGreen {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh) rotate(16.315deg);
-    }
-    55% {
-      transform: translateY(0) rotate(16.315deg);
-    }
-    70% {
-      transform: translateY(-15px) rotate(16.315deg);
-    }
-    82% {
-      transform: translateY(0) rotate(16.315deg);
-    }
-    93% {
-      transform: translateY(-8px) rotate(16.315deg);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0) rotate(16.315deg);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transform: rotate(16.315deg);
-    transition: opacity 0.3s ease-in-out;
-  }
-
-  @keyframes dropWithBounceGreenMobile {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh) rotate(13.811deg);
-    }
-    55% {
-      transform: translateY(0) rotate(13.811deg);
-    }
-    70% {
-      transform: translateY(-15px) rotate(13.811deg);
-    }
-    82% {
-      transform: translateY(0) rotate(13.811deg);
-    }
-    93% {
-      transform: translateY(-8px) rotate(13.811deg);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0) rotate(13.811deg);
-    }
-  }
+  ${dropAnimation("1.3s", "0.3s")}
+  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 575px;
@@ -559,14 +487,8 @@ const StatCardGreen = styled.div<{ $isVisible: boolean }>`
     right: unset;
     width: 63.58%;
     height: 159.429px;
-    animation: ${({ $isVisible }) =>
-      $isVisible
-        ? "dropWithBounceGreenMobile 1.3s cubic-bezier(0.25, 0.1, 0.25, 1) 0.3s forwards"
-        : "none"};
-  }
-
-  @media (max-width: 767px) and (prefers-reduced-motion: reduce) {
-    transform: rotate(13.811deg);
+    --tilt: 13.811deg;
+    ${dropAnimation("1.3s", "0.3s")}
   }
 `;
 
@@ -583,40 +505,10 @@ const StatCardBrown = styled.div<{ $isVisible: boolean }>`
   align-items: flex-start;
   border-radius: clamp(15px, 2.83cqw, 24px);
   background: #876e00;
+  --tilt: 0deg;
   opacity: 0;
-  animation: ${({ $isVisible }) =>
-    $isVisible
-      ? "dropWithBounceBrown 1.1s cubic-bezier(0.25, 0.1, 0.25, 1) 0.1s forwards"
-      : "none"};
-
-  @keyframes dropWithBounceBrown {
-    0% {
-      opacity: 1;
-      transform: translateY(-100vh);
-    }
-    55% {
-      transform: translateY(0);
-    }
-    70% {
-      transform: translateY(-15px);
-    }
-    82% {
-      transform: translateY(0);
-    }
-    93% {
-      transform: translateY(-8px);
-    }
-    100% {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-    opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
-    transition: opacity 0.3s ease-in-out;
-  }
+  ${dropAnimation("1.1s", "0.1s")}
+  ${reducedMotion}
 
   @media (max-width: 767px) {
     bottom: 0;
@@ -625,9 +517,6 @@ const StatCardBrown = styled.div<{ $isVisible: boolean }>`
     left: unset;
     width: 74.49%;
     height: 196.608px;
-    animation: ${({ $isVisible }) =>
-      $isVisible
-        ? "dropWithBounceBrown 1.1s cubic-bezier(0.25, 0.1, 0.25, 1) forwards"
-        : "none"};
+    ${dropAnimation("1.1s", "0s")}
   }
 `;


### PR DESCRIPTION
## 요약

와플 히스토리 박스 드랍/바운스 모션 개선

## 변경 내역

다음과 같은 방법으로 박스의 드랍 및 바운스 모션을 개선했습니다
- keyframe 단위 animation-timing-function 적용: 낙하 구간은 가속, 상승 구간은 감속으로 분리하여 중력 구현
- % 기반 바운스: 바운스 높이를 -12% → -5% → -2%로 점점 작아지게 변경, 화면 크기에 비례하도록 수정
- squash & stretch 추가 
- 낙하 거리 정규화 : -100vh → -180%로 화면 크기 무관하게 일관된 낙하
- 코드 구조 개선: 중복 @ keyframes 5개를 회전 각도를 --tilt CSS 변수로 외부화한 단일 dropBounce keyframe으로 통합
- 접근성/반응형 보존

## 체크리스트

- [ ] pre-commit 통과
- [ ] PR Assignees 추가
- [ ] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
