### PR TITLE
✨ 리크루팅 상단바 로그인 후 원래 페이지로 리디렉션

### DIFF
--- a/src/apis/recruiting/recruiting.types.ts
+++ b/src/apis/recruiting/recruiting.types.ts
@@ -60,7 +60,7 @@ export type BriefRecruiting = {
 
 type RecruitingInfoResponse = {
   id: number;
-  type: RecruitingTypeV2;
+  type: RecruitingType;
   info_num: number;
   title: string;
   date_info: string;

--- a/src/components/home/Header/Header.tsx
+++ b/src/components/home/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { zIndex } from "../../../lib/zIndex";
 import { useQuery } from "@tanstack/react-query";
@@ -8,7 +8,10 @@ import { useQueryClient } from "@tanstack/react-query";
 
 export default function Header() {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
+
+  const redirectPath = `${location.pathname}${location.search}${location.hash}`;
 
   /**
    * Check Authorization
@@ -51,7 +54,7 @@ export default function Header() {
         ) : (
           <NavButton
             onClick={() => {
-              navigate("/login");
+              navigate(`/login?redirect=${encodeURIComponent(redirectPath)}`);
             }}
           >
             <img src={"/icon/header/Login.svg"} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,14 +9,5 @@ export default defineConfig({
       timers: "rollup-plugin-node-polyfills/polyfills/timers",
     },
   },
-  server: {
-    proxy: {
-      "/api": {
-        target: "https://wacruit-dev.wafflestudio.com/",
-        changeOrigin: true,
-        secure: false,
-      },
-    },
-  },
   plugins: [react(), svgr()],
 });


### PR DESCRIPTION
## 요약

리크루팅 상단바 로그인 후 원래 페이지로 복귀하도록 수정하고, API 타입 불일치와 죽은 dev 프록시 설정을 정리했습니다.

## 변경 내역

- 리크루팅 상단바의 로그인 버튼을 누른 후 로그인을 하면 기존엔 메인 페이지로 리디렉션되었으나, 리크루팅 페이지에 머물 수 있도록 수정하였습니다. 
- RecruitingInfoResponse type이 API아 맞지 않아 숫자 enum으로 수정하였습니다. 
- `server.proxy`의 target인 wacruit-dev.wafflestudio.com을 쓰지 않아 코드를 정리하였습니다. 

## 체크리스트

- [ ] pre-commit 통과
- [ ] PR Assignees 추가
- [ ] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
