### PR TITLE
✨ 리크루팅 지원 화면 UI/UX 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rehype-katex": "^6.0.3",
     "rehype-mathjax": "^6.0.0",
     "rehype-raw": "^7.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
     "styled-components": "^6.0.0-rc.3",

--- a/src/GlobalStyles.tsx
+++ b/src/GlobalStyles.tsx
@@ -12,6 +12,14 @@ const GlobalStyles = createGlobalStyle`
     box-sizing: border-box;
   }
 
+  strong, b {
+    font-weight: 700;
+  }
+
+  em, i {
+    font-style: italic;
+  }
+
   body {
     font-family: Pretendard, sans-serif;
     text-decoration: none;

--- a/src/apis/member/member.api.ts
+++ b/src/apis/member/member.api.ts
@@ -1,4 +1,5 @@
 import { getJSON } from "../../features/member/utils";
+import { BASE_URL } from "../environment";
 
 export type ApiPosition =
   | "FRONTEND"
@@ -49,7 +50,7 @@ export async function fetchSponsors(
   if (query?.year != null) params.set("year", String(query.year));
   const qs = params.toString();
   const data = await getJSON<ApiSponsorResponse>(
-    `/api/v3/sponsor${qs ? `?${qs}` : ""}`,
+    `${BASE_URL}/v3/sponsor${qs ? `?${qs}` : ""}`,
   );
   return data.items ?? [];
 }
@@ -63,7 +64,7 @@ export async function fetchMembers(
   params.set("limit", String(query.limit ?? 200));
 
   const data = await getJSON<ApiMemberResponse>(
-    `/api/v3/members?${params.toString()}`,
+    `${BASE_URL}/v3/members?${params.toString()}`,
   );
   return data.items ?? [];
 }

--- a/src/apis/problem/problem.types.ts
+++ b/src/apis/problem/problem.types.ts
@@ -21,9 +21,9 @@ export enum LanguageCode {
 
 export enum LanguageCodeV2 {
   C = "c",
-  CPP = "c++",
+  CPP = "cpp",
   JAVA = "java",
-  JAVASCRIPT = "javascript",
+  JAVASCRIPT = "node",
   PYTHON = "python",
   KOTLIN = "kotlin",
   SWIFT = "swift",

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,1 +1,3 @@
 export const MAIL_RECRUIT = "recruit@wafflestudio.com";
+
+export const ORIENTATION_DATE = "9월 첫째 주";

--- a/src/common/const.ts
+++ b/src/common/const.ts
@@ -1,3 +1,3 @@
 export const MAIL_RECRUIT = "recruit@wafflestudio.com";
 
-export const ORIENTATION_DATE = "9월 첫째 주";
+export const ORIENTATION_DATE = "2026년 9월 4일 (금요일)";

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -12,9 +12,16 @@ export default function AlertModal({
   onClose,
 }: AlertModalProps) {
   return (
-    <Dialog role="alertdialog" aria-modal="true" aria-labelledby="alert-title">
+    <Dialog
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="alert-title"
+      aria-describedby={description ? "alert-description" : undefined}
+    >
       <Title id="alert-title">{title}</Title>
-      {description && <Description>{description}</Description>}
+      {description && (
+        <Description id="alert-description">{description}</Description>
+      )}
       <Buttons>
         <ConfirmButton type="button" onClick={onClose} autoFocus>
           확인

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -1,0 +1,76 @@
+import styled from "styled-components";
+
+type AlertModalProps = {
+  title: string;
+  description?: string;
+  onClose: () => void;
+};
+
+export default function AlertModal({
+  title,
+  description,
+  onClose,
+}: AlertModalProps) {
+  return (
+    <Dialog role="alertdialog" aria-modal="true" aria-labelledby="alert-title">
+      <Title id="alert-title">{title}</Title>
+      {description && <Description>{description}</Description>}
+      <Buttons>
+        <ConfirmButton type="button" onClick={onClose} autoFocus>
+          확인
+        </ConfirmButton>
+      </Buttons>
+    </Dialog>
+  );
+}
+
+const Dialog = styled.div`
+  box-sizing: border-box;
+  width: min(44rem, calc(100vw - 4rem));
+  padding: 3.2rem;
+  border-radius: 0.8rem;
+  background: #fff;
+  box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.18);
+  font-family: Pretendard, sans-serif;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  color: #222;
+  font-size: 2.2rem;
+  font-weight: 700;
+  line-height: 140%;
+  white-space: pre-line;
+`;
+
+const Description = styled.p`
+  margin: 1.2rem 0 0;
+  color: #737373;
+  font-size: 1.6rem;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.064rem;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 3rem;
+`;
+
+const ConfirmButton = styled.button`
+  padding: 1.2rem 2.4rem;
+  border: 0.1rem solid #f0745f;
+  border-radius: 0.5rem;
+  background: #f0745f;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background: #e05c46;
+    border-color: #e05c46;
+  }
+`;

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -6,6 +6,7 @@ type ConfirmModalProps = {
   confirmLabel: string;
   onConfirm: () => void;
   onClose: () => void;
+  irreversible?: boolean;
 };
 
 export default function ConfirmModal({
@@ -14,20 +15,26 @@ export default function ConfirmModal({
   confirmLabel,
   onConfirm,
   onClose,
+  irreversible = false,
 }: ConfirmModalProps) {
   return (
     <Dialog
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="confirm-title"
+      aria-describedby="confirm-description"
     >
       <Title id="confirm-title">{title}</Title>
-      <Description>{description}</Description>
+      <Description id="confirm-description">{description}</Description>
       <Buttons>
-        <CloseButton type="button" onClick={onClose}>
+        <CloseButton type="button" onClick={onClose} autoFocus={irreversible}>
           닫기
         </CloseButton>
-        <ConfirmButton type="button" onClick={onConfirm} autoFocus>
+        <ConfirmButton
+          type="button"
+          onClick={onConfirm}
+          autoFocus={!irreversible}
+        >
           {confirmLabel}
         </ConfirmButton>
       </Buttons>

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -1,0 +1,104 @@
+import styled from "styled-components";
+
+type ConfirmModalProps = {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onClose: () => void;
+};
+
+export default function ConfirmModal({
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onClose,
+}: ConfirmModalProps) {
+  return (
+    <Dialog
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-title"
+    >
+      <Title id="confirm-title">{title}</Title>
+      <Description>{description}</Description>
+      <Buttons>
+        <CloseButton type="button" onClick={onClose}>
+          닫기
+        </CloseButton>
+        <ConfirmButton type="button" onClick={onConfirm} autoFocus>
+          {confirmLabel}
+        </ConfirmButton>
+      </Buttons>
+    </Dialog>
+  );
+}
+
+const Dialog = styled.div`
+  box-sizing: border-box;
+  width: min(44rem, calc(100vw - 4rem));
+  padding: 3.2rem;
+  border-radius: 0.8rem;
+  background: #fff;
+  box-shadow: 0 0.4rem 2.4rem rgba(0, 0, 0, 0.18);
+  font-family: Pretendard, sans-serif;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  color: #222;
+  font-size: 2.2rem;
+  font-weight: 700;
+  line-height: 140%;
+`;
+
+const Description = styled.p`
+  margin: 1.2rem 0 0;
+  color: #737373;
+  font-size: 1.6rem;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.064rem;
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 3rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column-reverse;
+  }
+`;
+
+const BaseButton = styled.button`
+  padding: 1.2rem 2.4rem;
+  border-radius: 0.5rem;
+  font-family: inherit;
+  font-size: 1.6rem;
+  font-weight: 600;
+  cursor: pointer;
+`;
+
+const CloseButton = styled(BaseButton)`
+  border: 0.1rem solid #d1d1d1;
+  background: #fff;
+  color: #515151;
+
+  &:hover {
+    background: #f6f6f6;
+  }
+`;
+
+const ConfirmButton = styled(BaseButton)`
+  border: 0.1rem solid #f0745f;
+  background: #f0745f;
+  color: #fff;
+
+  &:hover {
+    background: #e05c46;
+    border-color: #e05c46;
+  }
+`;

--- a/src/components/home/Header/Header.tsx
+++ b/src/components/home/Header/Header.tsx
@@ -42,32 +42,34 @@ export default function Header() {
       <Nav>
         {authState === "valid" ? (
           <NavButton
+            aria-label="로그아웃"
             onClick={() => {
               deleteToken();
               queryClient.invalidateQueries(["auth"]);
               navigate("/");
             }}
           >
-            <img src={"/icon/header/Logout.svg"} />
-            로그아웃
+            <img src={"/icon/header/Logout.svg"} alt="" />
+            <span>로그아웃</span>
           </NavButton>
         ) : (
           <NavButton
+            aria-label="로그인"
             onClick={() => {
               navigate(`/login?redirect=${encodeURIComponent(redirectPath)}`);
             }}
           >
-            <img src={"/icon/header/Login.svg"} />
-            로그인
+            <img src={"/icon/header/Login.svg"} alt="" />
+            <span>로그인</span>
           </NavButton>
         )}
-        <NavLink to={"/recruiting"}>
-          <img src={"/icon/header/Apply.svg"} />
-          지원페이지
+        <NavLink to={"/recruiting"} aria-label="지원페이지">
+          <img src={"/icon/header/Apply.svg"} alt="" />
+          <span>지원페이지</span>
         </NavLink>
-        <NavLink to="/announcement">
-          <img src={"/icon/header/Alarm.svg"} />
-          공지사항
+        <NavLink to="/announcement" aria-label="공지사항">
+          <img src={"/icon/header/Alarm.svg"} alt="" />
+          <span>공지사항</span>
         </NavLink>
       </Nav>
     </Container>
@@ -80,35 +82,59 @@ const Container = styled.header`
   left: 0;
   z-index: ${zIndex.header};
   width: 100%;
-  height: 7vh;
+  height: 6.4rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 max(calc(50vw - 650px), 30px);
+  padding: 0 max(calc(50vw - 65rem), 3rem);
   background: #fff;
-  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.05);
   box-sizing: border-box;
   font-family: Pretendard, sans-serif;
+
+  @media (max-width: 768px) {
+    height: 5.6rem;
+    padding: 0 2rem;
+  }
 `;
 
 const Nav = styled.nav`
   display: flex;
-  gap: 48px;
+  gap: 4.8rem;
   color: #222;
-  font-size: 18px;
+  font-size: 1.8rem;
   font-weight: 500;
   white-space: nowrap;
+
+  @media (max-width: 1200px) {
+    gap: 3.2rem;
+  }
+
+  @media (max-width: 768px) {
+    gap: 2rem;
+    font-size: 1.4rem;
+  }
 `;
 
 const NavLinkStyle = css`
   position: relative;
   display: inline-flex;
-  gap: 5px;
+  align-items: center;
+  gap: 0.5rem;
   font: inherit;
   color: inherit;
   cursor: pointer;
   > img {
-    height: 18px;
+    height: 1.8rem;
+  }
+
+  @media (max-width: 480px) {
+    > span {
+      display: none;
+    }
+    > img {
+      height: 2.2rem;
+    }
   }
 `;
 
@@ -121,7 +147,8 @@ const NavButton = styled.button`
 `;
 
 const LoadAuth = styled.div`
-  width: 300px;
+  width: 30rem;
+  max-width: 60%;
   height: 80%;
   border-radius: 10px;
   animation: ${LoadingBackgroundBlink};

--- a/src/components/programmer/ProgrammerRecruitInfo.tsx
+++ b/src/components/programmer/ProgrammerRecruitInfo.tsx
@@ -12,11 +12,11 @@ export const ProgrammerRecruitInfo = () => {
       detail: "예. 010-1234-5678",
     },
     {
-      contents: "슬랙, 노션, 깃허브 초대를 위한 이메일",
+      contents: "디스코드, 노션, 깃허브 초대를 위한 이메일",
       detail: (
         <>
           세 가지에 대해 모두 작성해주세요. (예. 깃허브
-          example_github@gmail.com, 슬랙/노션 example_slack@naver.com)
+          example_github@gmail.com, 디스코드/노션 example_discord@naver.com)
         </>
       ),
     },

--- a/src/components/rookie/Progress/PortfolioCard.tsx
+++ b/src/components/rookie/Progress/PortfolioCard.tsx
@@ -157,6 +157,7 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
           title="포트폴리오를 삭제할까요?"
           description="업로드한 파일이 삭제되며 되돌릴 수 없습니다."
           confirmLabel="삭제하기"
+          irreversible
           onConfirm={deleteFile}
           onClose={() => {
             setDeleteTargetId(null);

--- a/src/components/rookie/Progress/PortfolioCard.tsx
+++ b/src/components/rookie/Progress/PortfolioCard.tsx
@@ -68,13 +68,11 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
     alertModal.openModal();
   };
 
-  const handleAPIError = async (error: unknown) => {
-    openAlert(
-      await resolveApiErrorMessage(
-        error,
-        "요청을 처리하지 못했습니다. 잠시 후 다시 시도해주세요.",
-      ),
-    );
+  const handleAPIError = async (
+    error: unknown,
+    fallback = "요청을 처리하지 못했습니다. 잠시 후 다시 시도해주세요.",
+  ) => {
+    openAlert(await resolveApiErrorMessage(error, fallback));
   };
 
   const [linksInput, setLinksInput] = useState<
@@ -203,8 +201,8 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
               <File
                 key={file_id}
                 onClick={() => {
-                  downloadPortfolioFile(file_id).catch(() =>
-                    openAlert("다운로드에 실패했습니다."),
+                  downloadPortfolioFile(file_id).catch((error: unknown) =>
+                    handleAPIError(error, "다운로드에 실패했습니다."),
                   );
                 }}
               >

--- a/src/components/rookie/Progress/PortfolioCard.tsx
+++ b/src/components/rookie/Progress/PortfolioCard.tsx
@@ -14,6 +14,11 @@ import {
 } from "../../../apis/portfolio/portfolio.api";
 import { LoadingBackgroundBlink } from "../../../lib/loading";
 import { Recruiting } from "../../../apis/recruiting/recruiting.types";
+import Modal from "../../Modal/Modal";
+import ConfirmModal from "../../Modal/ConfirmModal";
+import AlertModal from "../../Modal/AlertModal";
+import useModals from "../../Modal/useModals";
+import { resolveApiErrorMessage } from "../../../lib/apiErrorMessage";
 
 type PortfolioCardProps = {
   recruiting: Recruiting;
@@ -22,6 +27,10 @@ type PortfolioCardProps = {
 export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
+  const [replaceModal, deleteModal, alertModal] = useModals(3);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  const [alertMessage, setAlertMessage] = useState("");
 
   const { data: files } = useQuery({
     queryKey: ["portfolio", "files", recruiting.id],
@@ -54,8 +63,18 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
     );
   };
 
-  const handleAPIError = (r: Response) => {
-    r.json().then((res) => alert(res.detail));
+  const openAlert = (message: string) => {
+    setAlertMessage(message);
+    alertModal.openModal();
+  };
+
+  const handleAPIError = async (error: unknown) => {
+    openAlert(
+      await resolveApiErrorMessage(
+        error,
+        "요청을 처리하지 못했습니다. 잠시 후 다시 시도해주세요.",
+      ),
+    );
   };
 
   const [linksInput, setLinksInput] = useState<
@@ -69,19 +88,88 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
   ]);
 
   useEffect(() => {
-    if (links) {
-      const updated = linksInput.map((input, index) =>
-        links.items[index] ? links.items[index] : { id: null, url: "" },
-      );
-      setLinksInput(updated);
-    }
-  }, [links, linksInput]);
+    if (!links) return;
+    setLinksInput((prev) =>
+      prev.map((_, index) => links.items[index] ?? { id: null, url: "" }),
+    );
+  }, [links]);
+
+  const clearFileInput = () => {
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const replaceFile = () => {
+    replaceModal.closeModal();
+    const target = pendingFile;
+    const previousId = files?.items[0]?.id;
+    setPendingFile(null);
+    if (!target || previousId === undefined) return;
+    deletePortfolioFile(previousId)
+      .then(() => postPortfolioFile(target, recruiting.id))
+      .catch(handleAPIError)
+      .finally(refetchFiles);
+  };
+
+  const deleteFile = () => {
+    deleteModal.closeModal();
+    const target = deleteTargetId;
+    setDeleteTargetId(null);
+    if (target === null) return;
+    deletePortfolioFile(target)
+      .then(clearFileInput)
+      .catch(handleAPIError)
+      .finally(refetchFiles);
+  };
 
   if (files === undefined || links === undefined)
     return <EmptyCard></EmptyCard>;
 
   return (
     <Card $submit={submit}>
+      <Modal
+        handle={replaceModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+        onBackgroundClicked={() => {
+          setPendingFile(null);
+          replaceModal.closeModal();
+        }}
+      >
+        <ConfirmModal
+          title="포트폴리오를 교체할까요?"
+          description="기존에 업로드한 포트폴리오가 삭제되고 새로 선택한 파일로 바뀝니다."
+          confirmLabel="교체하기"
+          onConfirm={replaceFile}
+          onClose={() => {
+            setPendingFile(null);
+            replaceModal.closeModal();
+          }}
+        />
+      </Modal>
+      <Modal
+        handle={deleteModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+        onBackgroundClicked={() => {
+          setDeleteTargetId(null);
+          deleteModal.closeModal();
+        }}
+      >
+        <ConfirmModal
+          title="포트폴리오를 삭제할까요?"
+          description="업로드한 파일이 삭제되며 되돌릴 수 없습니다."
+          confirmLabel="삭제하기"
+          onConfirm={deleteFile}
+          onClose={() => {
+            setDeleteTargetId(null);
+            deleteModal.closeModal();
+          }}
+        />
+      </Modal>
+      <Modal
+        handle={alertModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+      >
+        <AlertModal title={alertMessage} onClose={alertModal.closeModal} />
+      </Modal>
       <InfoSection>
         <img src={iconSrc} alt={iconAlt} />
         <Name>포트폴리오</Name>
@@ -95,25 +183,16 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
           type="file"
           id="portfolio"
           onChange={(e) => {
-            if (!e.target.files) return;
-            const targetFile = e.target.files[0];
+            const targetFile = e.target.files?.[0];
+            e.target.value = "";
+            if (!targetFile) return;
             if (files.items.length < 1) {
               postPortfolioFile(targetFile, recruiting.id)
                 .catch(handleAPIError)
                 .finally(refetchFiles);
             } else {
-              if (
-                confirm(
-                  "기존에 업로드한 포트폴리오가 삭제됩니다. 계속하시겠습니까?",
-                )
-              ) {
-                deletePortfolioFile(files.items[0].id)
-                  .then(() => postPortfolioFile(targetFile, recruiting.id))
-                  .catch(handleAPIError)
-                  .finally(refetchFiles);
-              } else {
-                e.target.value = "";
-              }
+              setPendingFile(targetFile);
+              replaceModal.openModal();
             }
           }}
         />
@@ -124,26 +203,20 @@ export default function PortfolioCard({ recruiting }: PortfolioCardProps) {
                 key={file_id}
                 onClick={() => {
                   downloadPortfolioFile(file_id).catch(() =>
-                    alert("다운로드에 실패했습니다."),
+                    openAlert("다운로드에 실패했습니다."),
                   );
                 }}
               >
                 {file_name}
                 <DeleteButton
+                  aria-label="포트폴리오 삭제"
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (confirm("포트폴리오를 삭제하시겠습니까?")) {
-                      deletePortfolioFile(file_id)
-                        .then(() => {
-                          if (fileInputRef.current === null) return;
-                          fileInputRef.current.value = "";
-                        })
-                        .catch(handleAPIError)
-                        .finally(refetchFiles);
-                    }
+                    setDeleteTargetId(file_id);
+                    deleteModal.openModal();
                   }}
                 >
-                  <img src="/icon/rookie/DeleteFile.svg" />
+                  <img src="/icon/rookie/DeleteFile.svg" alt="" />
                 </DeleteButton>
               </File>
             ))}
@@ -192,6 +265,7 @@ const EmptyCard = styled.li`
   position: relative;
   display: flex;
   width: 84rem;
+  max-width: 100%;
   height: 19.3rem;
   flex-shrink: 0;
   border-radius: 0.5rem;
@@ -209,12 +283,18 @@ const Card = styled.li<{
   border-radius: 0.5rem;
   border: 0.1rem solid #d1d1d1;
   padding: 2.7rem;
+  max-width: 100%;
   color: ${(props) => (props.$submit ? "#64CB3F" : "#F0745F")};
-  border: "0.1rem solid #D1D1D1";
-  background: "#fff";
+  background: #fff;
   gap: 1.4rem;
+
   &:hover {
-    background: "#f6f6f6";
+    background: #f6f6f6;
+  }
+
+  @media (max-width: 1200px) {
+    flex-direction: column;
+    height: auto;
   }
 `;
 

--- a/src/components/rookie/Progress/ProgressCard.tsx
+++ b/src/components/rookie/Progress/ProgressCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { styled } from "styled-components";
 import asset from "./progressCardAsset";
 import { ProblemStatusCode } from "../../../apis/recruiting/recruiting.types";
@@ -11,7 +11,6 @@ type ProgressCardProps = {
 };
 
 export function ProgressCard({ title, statusCode, to }: ProgressCardProps) {
-  const navigate = useNavigate();
   const { iconSrc, iconAlt, theme, description } = useMemo(() => {
     switch (statusCode) {
       case ProblemStatusCode.NOT_SUBMITTED:
@@ -28,29 +27,40 @@ export function ProgressCard({ title, statusCode, to }: ProgressCardProps) {
   }, [statusCode]);
 
   return (
-    <Card $theme={theme} onClick={() => navigate(to)}>
-      <img src={iconSrc} alt={iconAlt} />
-      <Name>{title}</Name>
-      <Description>{description}</Description>
-      <Button>
-        <img src={"/icon/rookie/CardRightArrow.svg"} width={24} />
-      </Button>
-    </Card>
+    <Item>
+      <Card $theme={theme} to={to}>
+        <img src={iconSrc} alt={iconAlt} />
+        <Name>{title}</Name>
+        <Description>{description}</Description>
+        <Arrow aria-hidden="true">
+          <img src="/icon/rookie/CardRightArrow.svg" alt="" width={24} />
+        </Arrow>
+      </Card>
+    </Item>
   );
 }
 
-const Card = styled.li<{
+const Item = styled.li`
+  display: flex;
+  flex-shrink: 0;
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const Card = styled(Link)<{
   $theme: "red" | "green" | "yellow" | "gray";
 }>`
   position: relative;
   box-sizing: border-box;
+  display: block;
   width: 28rem;
   height: 19.3rem;
-  flex-shrink: 0;
   border-radius: 0.5rem;
-  border: 0.1rem solid #d1d1d1;
   padding: 2.7rem;
   cursor: pointer;
+  text-decoration: none;
   color: ${(props) =>
     props.$theme === "green"
       ? "#45B61D"
@@ -88,9 +98,18 @@ const Card = styled.li<{
         ? "linear-gradient(180deg, #FFF7CE 0%, #F6F6F6 46.88%);"
         : "#f6f6f6"};
   }
+
+  &:focus-visible {
+    outline: 0.3rem solid #f0745f;
+    outline-offset: 0.3rem;
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
 `;
 
-const Name = styled.h1`
+const Name = styled.h3`
   font-size: 2.4rem;
   font-weight: 600;
   margin-top: 1.6rem;
@@ -106,14 +125,15 @@ const Description = styled.p`
   margin: 0;
 `;
 
-const Button = styled.button`
+const Arrow = styled.span`
   position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 3rem;
   height: 3rem;
-  padding: 0.2rem 0 0 0;
   border-radius: 50%;
   border: 0.1rem solid #737373;
   right: 2.7rem;
   bottom: 2.7rem;
-  background: none;
 `;

--- a/src/components/rookie/Progress/ProgressList.tsx
+++ b/src/components/rookie/Progress/ProgressList.tsx
@@ -79,7 +79,9 @@ export function ProgressList({
 
 const List = styled.ul`
   display: flex;
+  flex-wrap: wrap;
   gap: 2rem;
   list-style: none;
   padding: 0;
+  margin: 0;
 `;

--- a/src/components/rookie/Progress/ResumeCard.tsx
+++ b/src/components/rookie/Progress/ResumeCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import styled from "styled-components";
 import asset from "./progressCardAsset";
 
@@ -8,47 +8,66 @@ type ResumeCardProps = {
 };
 
 export function ResumeCard({ submit }: ResumeCardProps) {
-  const navigate = useNavigate();
   const { iconSrc, iconAlt, description } = useMemo(
     () => (submit ? asset.resumeSubmit : asset.resumeNotSubmit),
     [submit],
   );
 
   return (
-    <Card $submit={submit} onClick={() => navigate("./resume")}>
-      <img src={iconSrc} alt={iconAlt} />
-      <Name>자기소개서</Name>
-      <Description>{description}</Description>
-      <Button>
-        <img src={"/icon/rookie/CardRightArrow.svg"} width={24} />
-      </Button>
-    </Card>
+    <Item>
+      <Card $submit={submit} to="./resume">
+        <img src={iconSrc} alt={iconAlt} />
+        <Name>자기소개서</Name>
+        <Description>{description}</Description>
+        <Arrow aria-hidden="true">
+          <img src="/icon/rookie/CardRightArrow.svg" alt="" width={24} />
+        </Arrow>
+      </Card>
+    </Item>
   );
 }
 
-const Card = styled.li<{
+const Item = styled.li`
+  display: flex;
+  flex-shrink: 0;
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const Card = styled(Link)<{
   $submit: boolean;
 }>`
   position: relative;
   box-sizing: border-box;
+  display: block;
   width: 28rem;
   height: 19.3rem;
-  flex-shrink: 0;
   border-radius: 0.5rem;
-  border: 0.1rem solid #d1d1d1;
   padding: 2.7rem;
   cursor: pointer;
+  text-decoration: none;
+  background: #fff;
   color: ${(props) => (props.$submit ? "#64CB3F" : "#F0745F")};
   border: ${(props) =>
     props.$submit ? "0.1rem solid #64CB3F" : "0.1rem solid #D1D1D1"};
-  background: "#fff";
 
   &:hover {
-    background: "#f6f6f6";
+    background: #f6f6f6;
+  }
+
+  &:focus-visible {
+    outline: 0.3rem solid #f0745f;
+    outline-offset: 0.3rem;
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
   }
 `;
 
-const Name = styled.h1`
+const Name = styled.h3`
   font-size: 2.4rem;
   font-weight: 600;
   margin-top: 1.6rem;
@@ -64,14 +83,15 @@ const Description = styled.p`
   margin: 0;
 `;
 
-const Button = styled.button`
+const Arrow = styled.span`
   position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 3rem;
   height: 3rem;
-  padding: 0.2rem 0 0 0;
   border-radius: 50%;
   border: 0.1rem solid #737373;
   right: 2.7rem;
   bottom: 2.7rem;
-  background: none;
 `;

--- a/src/components/rookie/Progress/progressCardAsset.ts
+++ b/src/components/rookie/Progress/progressCardAsset.ts
@@ -10,13 +10,13 @@ type ProgressCardAsset = CardAsset & {
 //resume
 const resumeSubmit: CardAsset = {
   iconSrc: "/icon/rookie/Check.svg",
-  iconAlt: "제출 완료 아이콘",
-  description: "제출 완료",
+  iconAlt: "저장 완료 아이콘",
+  description: "저장 완료",
 };
 const resumeNotSubmit: CardAsset = {
   iconSrc: "/icon/rookie/Pencil.svg",
-  iconAlt: "미제출 아이콘",
-  description: "미제출",
+  iconAlt: "작성 전 아이콘",
+  description: "작성 전",
 };
 
 //portfolio

--- a/src/components/rookie/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/rookie/UserInfoForm/UserInfoForm.tsx
@@ -43,7 +43,7 @@ const UserInfoForm = forwardRef<HTMLFormElement, UserInfoFormProps>(
           placeholder="example@gmail.com"
           type="email"
         >
-          슬랙 초대 이메일
+          디스코드 초대 이메일
         </LabeledInput>
         <LabeledInput
           name="notion_email"

--- a/src/components/solve/ProblemDescription/ProblemDescription.tsx
+++ b/src/components/solve/ProblemDescription/ProblemDescription.tsx
@@ -163,6 +163,23 @@ const ProblemTitle = styled.h1`
 // `;
 
 const MarkdownStyledWrapper = styled.div`
+  font-size: 1.8rem;
+  line-height: 160%;
+
+  table {
+    border-collapse: collapse;
+    margin: 1.6rem 0;
+  }
+  th,
+  td {
+    border: 0.1rem solid #d1d1d1;
+    padding: 0.6rem 1.2rem;
+  }
+  th {
+    background: #f6f6f6;
+    font-weight: 600;
+  }
+
   h1 {
     font-size: 4rem;
     line-height: 160%;

--- a/src/components/solve/ProblemDescription/ProblemDescription.tsx
+++ b/src/components/solve/ProblemDescription/ProblemDescription.tsx
@@ -167,6 +167,9 @@ const MarkdownStyledWrapper = styled.div`
   line-height: 160%;
 
   table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
     border-collapse: collapse;
     margin: 1.6rem 0;
   }

--- a/src/components/solve/ProblemTabs.tsx
+++ b/src/components/solve/ProblemTabs.tsx
@@ -1,0 +1,158 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import asset from "../rookie/Progress/progressCardAsset";
+import { ProblemStatusCode } from "../../apis/recruiting/recruiting.types";
+
+type ProblemTab = {
+  id: number;
+  num: number;
+  status: ProblemStatusCode;
+};
+
+type ProblemTabsProps = {
+  recruitId: number;
+  problems: ProblemTab[];
+  currentProblemId: number;
+  judgingProblemId?: number;
+};
+
+const statusAsset = (status: ProblemStatusCode) => {
+  switch (status) {
+    case ProblemStatusCode.JUDGING:
+      return asset.problemJudging;
+    case ProblemStatusCode.CORRECT:
+      return asset.problemSubmitCorrect;
+    case ProblemStatusCode.WRONG:
+      return asset.problemSubmitWrong;
+    default:
+      return asset.problemNotSubmit;
+  }
+};
+
+const dotColors = {
+  green: "#45B61D",
+  yellow: "#FFB800",
+  red: "#C7382A",
+  gray: "#9A9A9A",
+} as const;
+
+export default function ProblemTabs({
+  recruitId,
+  problems,
+  currentProblemId,
+  judgingProblemId,
+}: ProblemTabsProps) {
+  return (
+    <Nav>
+      <BackLink to={`/recruiting/${recruitId}`}>
+        <img src="/icon/LeftArrow.svg" alt="" width={31} />
+        Back
+      </BackLink>
+      {problems.length > 0 && (
+        <TabList>
+          {problems.map(({ id, num, status }) => {
+            const { theme, description } = statusAsset(
+              id === judgingProblemId ? ProblemStatusCode.JUDGING : status,
+            );
+            const isCurrent = id === currentProblemId;
+            return (
+              <li key={id}>
+                <Tab
+                  to={`/recruiting/${recruitId}/solve/${id}`}
+                  $current={isCurrent}
+                  aria-current={isCurrent ? "page" : undefined}
+                  title={`문제 ${num} · ${description}`}
+                >
+                  <Dot $color={dotColors[theme]} aria-hidden="true" />
+                  문제 {num}
+                  <HiddenText>{description}</HiddenText>
+                </Tab>
+              </li>
+            );
+          })}
+        </TabList>
+      )}
+    </Nav>
+  );
+}
+
+const Nav = styled.nav`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.2rem 2rem;
+  padding: 1.4rem;
+  background: #f0745f;
+  border-bottom: 0.4rem solid #373737;
+`;
+
+const BackLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-weight: bold;
+  font-size: 1.6rem;
+  color: #000000;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:focus-visible {
+    outline: 0.3rem solid #373737;
+    outline-offset: 0.3rem;
+  }
+`;
+
+const TabList = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0 0 0 1.2rem;
+  list-style: none;
+  border-left: 0.2rem solid rgba(55, 55, 55, 0.35);
+`;
+
+const Tab = styled(Link)<{ $current: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 1.2rem;
+  border: 0.2rem solid
+    ${(props) => (props.$current ? "#373737" : "transparent")};
+  border-radius: 0.5rem;
+  background: ${(props) =>
+    props.$current ? "#fff" : "rgba(255,255,255,0.35)"};
+  color: #373737;
+  font-size: 1.5rem;
+  font-weight: ${(props) => (props.$current ? 700 : 500)};
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover {
+    background: #fff;
+  }
+
+  &:focus-visible {
+    outline: 0.3rem solid #373737;
+    outline-offset: 0.2rem;
+  }
+`;
+
+const Dot = styled.span<{ $color: string }>`
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: ${(props) => props.$color};
+`;
+
+const HiddenText = styled.span`
+  position: absolute;
+  width: 0.1rem;
+  height: 0.1rem;
+  padding: 0;
+  margin: -0.1rem;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;

--- a/src/components/solve/ProblemTabs.tsx
+++ b/src/components/solve/ProblemTabs.tsx
@@ -43,7 +43,7 @@ export default function ProblemTabs({
   judgingProblemId,
 }: ProblemTabsProps) {
   return (
-    <Nav>
+    <Nav aria-label="문제 목록">
       <BackLink to={`/recruiting/${recruitId}`}>
         <img src="/icon/LeftArrow.svg" alt="" width={31} />
         Back
@@ -113,6 +113,7 @@ const TabList = styled.ul`
 `;
 
 const Tab = styled(Link)<{ $current: boolean }>`
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;

--- a/src/components/solve/TestResultConsoleV2.tsx
+++ b/src/components/solve/TestResultConsoleV2.tsx
@@ -36,10 +36,10 @@ export default function TestResultConsole(props: Props) {
           </li>
         ))}
         {props.error.map((err, i) => (
-          <li key={i}>
+          <ErrorItem key={i}>
             <h4>에러 {i + 1}</h4>
             <pre>{err}</pre>
-          </li>
+          </ErrorItem>
         ))}
       </ul>
     </Section>
@@ -78,6 +78,15 @@ const Section = styled.section`
 
 const SectionTitle = styled.h3`
   font-size: 1.6rem;
+`;
+
+const ErrorItem = styled.li`
+  color: #c7382a;
+
+  pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
 `;
 
 const Status = styled.p<{ $status: string }>`

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -15,7 +15,7 @@ function preprocessMarkdown(src: string) {
 
   // 1) 개행/공백 정규화
   s = s.replace(/\r\n?/g, "\n"); // CRLF/CR → LF
-  s = s.replace(/\\n/g, "\n"); // 문자열로 들어온 "\n" → 실제 LF
+  s = s.replace(/\\n(?![a-zA-Z])/g, "\n"); // 문자열로 들어온 "\n" → 실제 LF
   s = s.replace(/[\u2028\u2029]/g, "\n"); // 유니코드 line/paragraph separator → LF
   s = s.replace(/\u00A0/g, " "); // nbsp → 일반 공백
   s = s.replace(/[\u200B-\u200D\uFEFF]/g, ""); // zero-width chars 제거

--- a/src/lib/MarkdownRenderer.tsx
+++ b/src/lib/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import rehypeRaw from "rehype-raw";
 import remarkMath from "remark-math";
 // import rehypeKatex from "rehype-katex";
@@ -19,6 +20,15 @@ function preprocessMarkdown(src: string) {
   s = s.replace(/\u00A0/g, " "); // nbsp → 일반 공백
   s = s.replace(/[\u200B-\u200D\uFEFF]/g, ""); // zero-width chars 제거
 
+  s = s.replace(
+    /\\\[([\s\S]*?)\\\]/g,
+    (_, expr: string) => "\n$$\n" + expr.trim() + "\n$$\n",
+  );
+  s = s.replace(
+    /\\\(([\s\S]*?)\\\)/g,
+    (_, expr: string) => "$" + expr.trim() + "$",
+  );
+
   // 2) 얕은 HTML 래퍼 → 마크다운 문단/줄바꿈
   s = s.replace(/<br\s*\/?>/gi, "  \n"); // <br> → 마크다운 강제개행(스페이스2 + LF)
   s = s.replace(/<p[^>]*>/gi, "");
@@ -28,7 +38,7 @@ function preprocessMarkdown(src: string) {
   s = s.replace(/^(\d+)\.\s/gm, "$1\\. ");
 
   // 3) ATX 헤딩(#) 뒤에 공백 강제 (예: "###2." → "### 2.")
-  s = s.replace(/^(#{1,6})(?=\S)/gm, "$1 "); // 줄 시작에서 #...# 다음에 공백 없으면 넣기
+  s = s.replace(/^(#{1,6})(?=[^#\s])/gm, "$1 "); // 줄 시작에서 #...# 다음에 공백 없으면 넣기
 
   // 4) 구분선(---)이 텍스트 사이에 끼어있으면 앞뒤에 빈 줄 확보
   s = s.replace(/\s*^---\s*$/gm, "\n---\n");
@@ -39,6 +49,7 @@ function preprocessMarkdown(src: string) {
 function CustomReactMarkdown({ markdownString }: { markdownString: string }) {
   const remarkPlugins: PluggableList = [
     asPluggable(remarkGfm),
+    asPluggable(remarkBreaks),
     asPluggable(remarkMath),
   ];
   const rehypePlugins: PluggableList = [

--- a/src/lib/apiErrorMessage.ts
+++ b/src/lib/apiErrorMessage.ts
@@ -1,0 +1,11 @@
+const NETWORK_ERROR_MESSAGE = "네트워크 연결을 확인한 뒤 다시 시도해주세요.";
+
+export async function resolveApiErrorMessage(error: unknown, fallback: string) {
+  if (!(error instanceof Response)) return NETWORK_ERROR_MESSAGE;
+
+  const data = (await error.json().catch(() => null)) as {
+    detail?: unknown;
+  } | null;
+
+  return typeof data?.detail === "string" ? data.detail : fallback;
+}

--- a/src/lib/apiErrorMessage.ts
+++ b/src/lib/apiErrorMessage.ts
@@ -1,11 +1,15 @@
 const NETWORK_ERROR_MESSAGE = "네트워크 연결을 확인한 뒤 다시 시도해주세요.";
 
 export async function resolveApiErrorMessage(error: unknown, fallback: string) {
-  if (!(error instanceof Response)) return NETWORK_ERROR_MESSAGE;
+  if (error instanceof Response) {
+    const data = (await error.json().catch(() => null)) as {
+      detail?: unknown;
+    } | null;
 
-  const data = (await error.json().catch(() => null)) as {
-    detail?: unknown;
-  } | null;
+    return typeof data?.detail === "string" ? data.detail : fallback;
+  }
 
-  return typeof data?.detail === "string" ? data.detail : fallback;
+  if (error instanceof TypeError) return NETWORK_ERROR_MESSAGE;
+
+  return fallback;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,14 @@
+import { useState } from "react";
 import { styled } from "styled-components";
 import { ProgressList } from "../components/rookie/Progress/ProgressList";
 import Header from "../components/home/Header/Header";
 import { useLoaderData, useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import MarkdownRenderer from "../lib/MarkdownRenderer";
+import Modal from "../components/Modal/Modal";
+import ConfirmModal from "../components/Modal/ConfirmModal";
+import useModals from "../components/Modal/useModals";
+import { resolveApiErrorMessage } from "../lib/apiErrorMessage";
 import {
   DashboardLoaderReturnType,
   myResumeQuery,
@@ -20,18 +25,96 @@ export default function Dashboard() {
   const params = useParams();
   const navigate = useNavigate();
   const initialData = useLoaderData() as DashboardLoaderReturnType;
+  const recruitId = Number(params.recruit_id);
+
   const { data: recruiting } = useQuery({
-    ...recruitingDetailQuery(Number(params.recruit_id)),
+    ...recruitingDetailQuery(recruitId),
     initialData: initialData.recruiting,
   });
   const { data: resume } = useQuery({
-    ...myResumeQuery(Number(params.recruit_id)),
+    ...myResumeQuery(recruitId),
     initialData: initialData.resume,
   });
+
+  const [submitModal, cancelModal] = useModals(2);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const isProgrammer = recruiting.type === RecruitingType.PROGRAMMER;
+  const applied = recruiting.applied;
+  const isClosed =
+    recruiting.to_date !== undefined &&
+    recruiting.to_date !== null &&
+    new Date(recruiting.to_date).getTime() <= Date.now();
+
+  const refetchRecruiting = () =>
+    Promise.all([
+      queryClient.invalidateQueries(["recruiting"]),
+      queryClient.invalidateQueries(["resume"]),
+      queryClient.invalidateQueries(["user"]),
+    ]);
+
+  const handleApply = () => {
+    submitModal.closeModal();
+    setIsPending(true);
+    setErrorMessage(null);
+    applyRecruiting(recruiting.id)
+      .then(() => refetchRecruiting())
+      .catch(async (error: unknown) => {
+        setErrorMessage(
+          await resolveApiErrorMessage(
+            error,
+            "최종 제출에 실패했습니다. 잠시 후 다시 시도해주세요.",
+          ),
+        );
+      })
+      .finally(() => setIsPending(false));
+  };
+
+  const handleCancel = () => {
+    cancelModal.closeModal();
+    setIsPending(true);
+    setErrorMessage(null);
+    cancelRecruiting(recruiting.id)
+      .then(() => refetchRecruiting())
+      .catch(async (error: unknown) => {
+        setErrorMessage(
+          await resolveApiErrorMessage(
+            error,
+            "지원 취소에 실패했습니다. 잠시 후 다시 시도해주세요.",
+          ),
+        );
+      })
+      .finally(() => setIsPending(false));
+  };
 
   return (
     <>
       <Header />
+      <Modal
+        handle={submitModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+      >
+        <ConfirmModal
+          title="최종 제출할까요?"
+          description="제출 후에도 마감 전까지는 자기소개서와 문제 풀이를 계속 수정할 수 있습니다."
+          confirmLabel="최종 제출하기"
+          onConfirm={handleApply}
+          onClose={submitModal.closeModal}
+        />
+      </Modal>
+      <Modal
+        handle={cancelModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+      >
+        <ConfirmModal
+          title="지원을 취소할까요?"
+          description="입력한 자기소개서와 문제 제출 내역이 모두 삭제되며 되돌릴 수 없습니다."
+          confirmLabel="지원 취소하기"
+          onConfirm={handleCancel}
+          onClose={cancelModal.closeModal}
+        />
+      </Modal>
       <Main>
         <Title>
           <MarkdownRenderer
@@ -39,112 +122,77 @@ export default function Dashboard() {
             StyledWrapper={TitleMarkdownStyledWrapper}
           />
         </Title>
-        <Description>
-          {/* <MarkdownRenderer
-            markdownString={`와플스튜디오의 21.5기 ${
-              recruiting.id === 1 ? "루키" : "디자이너"
-            }를 모집합니다.`}
-            StyledWrapper={DescriptionMarkdownStyledWrapper}
-          /> */}
-        </Description>
         <Information>
           <MarkdownRenderer
             markdownString={recruiting.description}
             StyledWrapper={InformationMarkdownStyledWrapper}
           />
         </Information>
-        {/* <AnnouncementButton onClick={() => navigate("/announcement")}>
-          공지 및 변경사항 안내
-          <div>
-            <img
-              src="/icon/rookie/AnnounceRightArrow.svg"
-              alt="&rarr;"
-              width={20}
-            />
-            <img
-              src="/icon/rookie/AnnounceRightArrowWhite.svg"
-              alt="&rarr;"
-              width={20}
-            />
-          </div>
-        </AnnouncementButton> */}
-        {initialData.recruiting.applied &&
-          recruiting.type !== RecruitingType.PROGRAMMER && (
-            <AnnouncementButton onClick={() => navigate("./result")}>
-              지원 결과 확인하기
-              <div>
-                <img
-                  src="/icon/rookie/AnnounceRightArrow.svg"
-                  alt="&rarr;"
-                  width={20}
-                />
-                <img
-                  src="/icon/rookie/AnnounceRightArrowWhite.svg"
-                  alt="&rarr;"
-                  width={20}
-                />
-              </div>
-            </AnnouncementButton>
-          )}{" "}
-        {!initialData.recruiting.applied &&
-          recruiting.type !== RecruitingType.PROGRAMMER && (
-            <AnnouncementButton
-              onClick={() =>
-                applyRecruiting(recruiting.id)
-                  .then(() => {
-                    alert("지원이 완료되었습니다.");
-                    navigate(0);
-                  })
-                  .catch((res: Response) => {
-                    res.json().then((data) => {
-                      alert(data.detail);
-                    });
-                  })
-              }
-            >
-              지원하기
-            </AnnouncementButton>
-          )}
-        <BottomContainer>
-          <ProgressList
-            recruiting={recruiting}
-            hasResume={resume.items.length > 0}
-            type={recruiting.type}
-          />
-          {recruiting.type !== RecruitingType.PROGRAMMER && (
-            <Caution>
-              위 내용은 제출 후에도 상시 수정할 수 있으며, 모두 제출해야 지원
-              완료됩니다.
-              {initialData.recruiting.applied ? (
-                <CancelButton
-                  onClick={() => {
-                    if (
-                      confirm(
-                        "지원을 취소하면 입력한 자기소개서와 문제의 제출 내역이 모두 삭제됩니다. 정말로 지원을 취소하시겠습니까?",
-                      )
-                    ) {
-                      cancelRecruiting(recruiting.id)
-                        .then(() => {
-                          queryClient.invalidateQueries(["recruiting"]);
-                          queryClient.invalidateQueries(["resume"]);
-                          queryClient.invalidateQueries(["user"]);
-                          alert("지원이 취소되었습니다");
-                          navigate("/");
-                        })
-                        .catch((res: Response) => {
-                          res.json().then((data) => {
-                            alert(data.detail);
-                          });
-                        });
-                    }
-                  }}
+        <ProgressList
+          recruiting={recruiting}
+          hasResume={resume.items.length > 0}
+          type={recruiting.type}
+        />
+        {!isProgrammer && (
+          <>
+            {!isClosed && (
+              <Caution>
+                위 내용은 마감 전까지 상시 수정할 수 있으며, 모두 완료한 뒤 아래{" "}
+                <em>최종 제출하기</em> 버튼을 눌러야 지원이 완료됩니다.
+              </Caution>
+            )}
+            <ActionArea>
+              {isClosed ? (
+                applied ? (
+                  <ResultButton
+                    type="button"
+                    onClick={() => navigate("./result")}
+                  >
+                    지원 결과 확인하기
+                    <div>
+                      <img
+                        src="/icon/rookie/AnnounceRightArrow.svg"
+                        alt="&rarr;"
+                        width={20}
+                      />
+                      <img
+                        src="/icon/rookie/AnnounceRightArrowWhite.svg"
+                        alt="&rarr;"
+                        width={20}
+                      />
+                    </div>
+                  </ResultButton>
+                ) : (
+                  <ClosedText>지원이 마감되었습니다.</ClosedText>
+                )
+              ) : applied ? (
+                <ActionRow>
+                  <SubmitButton type="button" disabled $done>
+                    최종 제출 완료
+                  </SubmitButton>
+                  <CancelButton
+                    type="button"
+                    onClick={cancelModal.openModal}
+                    disabled={isPending}
+                  >
+                    지원 취소
+                  </CancelButton>
+                </ActionRow>
+              ) : (
+                <SubmitButton
+                  type="button"
+                  onClick={submitModal.openModal}
+                  disabled={isPending}
                 >
-                  지원 취소
-                </CancelButton>
-              ) : null}
-            </Caution>
-          )}
-        </BottomContainer>
+                  {isPending ? "제출하는 중..." : "최종 제출하기"}
+                </SubmitButton>
+              )}
+              {errorMessage && (
+                <ErrorText role="status">{errorMessage}</ErrorText>
+              )}
+            </ActionArea>
+          </>
+        )}
       </Main>
     </>
   );
@@ -155,8 +203,15 @@ const Main = styled.main`
   font-family: Pretendard, sans-serif;
   font-style: normal;
   line-height: normal;
-  padding: 23vh max(calc(50vw - 65rem), 3rem);
-  padding-bottom: 3rem;
+  padding: calc(6.4rem + 6rem) max(calc(50vw - 65rem), 3rem) 8rem;
+
+  @media (max-width: 1200px) {
+    padding: calc(6.4rem + 5rem) 4rem 6rem;
+  }
+
+  @media (max-width: 768px) {
+    padding: calc(5.6rem + 3rem) 2rem 4rem;
+  }
 `;
 
 const Title = styled.h1`
@@ -169,23 +224,12 @@ const TitleMarkdownStyledWrapper = styled.div`
     color: #222;
     font-size: 4.6rem;
     font-weight: 700;
+
+    @media (max-width: 768px) {
+      font-size: 3rem;
+    }
   }
 `;
-
-const Description = styled.p`
-  margin-top: 1.2rem;
-  margin-bottom: 3.5rem;
-`;
-
-// const DescriptionMarkdownStyledWrapper = styled.div`
-//   p {
-//     color: #373737;
-//     font-size: 2rem;
-//     font-weight: 500;
-//     line-height: 160%; /* 3.2rem */
-//     letter-spacing: 0.08rem;
-//   }
-// `;
 
 const Information = styled.div`
   margin-bottom: 3.4rem;
@@ -199,6 +243,10 @@ const InformationMarkdownStyledWrapper = styled.div`
     line-height: 170%; /* 3.06rem */
     letter-spacing: 0.072rem;
     margin: 0;
+
+    @media (max-width: 768px) {
+      font-size: 1.5rem;
+    }
   }
   code {
     color: #b44f3d;
@@ -216,23 +264,110 @@ const InformationMarkdownStyledWrapper = styled.div`
       font-weight: 400;
       line-height: 170%; /* 3.06rem */
       letter-spacing: 0.072rem;
+
+      @media (max-width: 768px) {
+        font-size: 1.5rem;
+      }
     }
   }
 `;
 
-const AnnouncementButton = styled.button`
+const Caution = styled.p`
+  margin: 2.5rem 0 0;
+  color: #515151;
+  font-size: 1.8rem;
+  font-weight: 400;
+  line-height: 160%; /* 2.88rem */
+  letter-spacing: 0.072rem;
+
+  em {
+    font-style: normal;
+    font-weight: 600;
+    color: #222;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
+`;
+
+const ClosedText = styled.p`
+  margin: 0;
+  color: #515151;
+  font-size: 1.8rem;
+  font-weight: 400;
+  line-height: 160%;
+  letter-spacing: 0.072rem;
+
+  @media (max-width: 768px) {
+    font-size: 1.5rem;
+  }
+`;
+
+const ActionArea = styled.div`
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
+  gap: 1.6rem;
+  margin-top: 3.2rem;
+`;
+
+const SubmitButton = styled.button<{ $done?: boolean }>`
+  box-sizing: border-box;
+  width: 32rem;
+  padding: 1.8rem;
+  background: #f0745f;
+  border: 0.1rem solid #f0745f;
+  border-radius: 0.5rem;
+  color: #fff;
+  font-family: inherit;
+  font-size: 2.2rem;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover:enabled {
+    background: #e05c46;
+    border-color: #e05c46;
+  }
+
+  &:disabled {
+    cursor: default;
+    background: ${(props) => (props.$done ? "#fff" : "#c4c4c4")};
+    border-color: ${(props) => (props.$done ? "#64cb3f" : "#c4c4c4")};
+    color: ${(props) => (props.$done ? "#45b61d" : "#fff")};
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
+    font-size: 1.8rem;
+  }
+`;
+
+const ActionRow = styled.div`
+  display: flex;
+  align-items: stretch;
+  gap: 2rem;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    justify-content: space-between;
+  }
+`;
+
+const ResultButton = styled.button`
+  display: flex;
+  align-items: center;
   gap: 1rem;
   padding: 1rem 2rem;
   background: #f0745f;
   border: #f0745f 0.1rem solid;
   border-radius: 0.5rem;
   color: #fff;
+  font-family: inherit;
   font-size: 1.8rem;
   font-weight: 500;
   line-height: 2.5rem;
-  margin-bottom: 3.4rem;
   cursor: pointer;
 
   > div {
@@ -264,29 +399,34 @@ const AnnouncementButton = styled.button`
   }
 `;
 
-const BottomContainer = styled.div`
-  display: inline-block;
-`;
-
-const Caution = styled.div`
-  position: relative;
-  color: #515151;
-  font-size: 1.8rem;
-  font-weight: 400;
-  line-height: 160%; /* 2.88rem */
-  letter-spacing: 0.072rem;
-  margin-top: 2.5rem;
-`;
-
 const CancelButton = styled.button`
-  position: absolute;
-  display: inline-block;
-  right: 0;
-  margin-top: 15.3rem;
-  background: none;
-  border: none;
+  padding: 1rem 2rem;
+  background: #fff;
+  border: 0.1rem solid #d1d1d1;
+  border-radius: 0.5rem;
+  color: #737373;
+  font-family: inherit;
+  font-size: 1.8rem;
+  font-weight: 500;
+  line-height: 2.5rem;
   cursor: pointer;
-  color: #c4c4c4;
-  font: inherit;
-  text-decoration-line: underline;
+
+  &:hover:enabled {
+    border-color: #737373;
+    color: #515151;
+  }
+
+  &:disabled {
+    cursor: default;
+    color: #c4c4c4;
+  }
+`;
+
+const ErrorText = styled.p`
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 500;
+  line-height: 160%;
+  color: #f0745f;
+  white-space: pre-line;
 `;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -43,9 +43,10 @@ export default function Dashboard() {
   const isProgrammer = recruiting.type === RecruitingType.PROGRAMMER;
   const applied = recruiting.applied;
   const isClosed =
-    recruiting.to_date !== undefined &&
-    recruiting.to_date !== null &&
-    new Date(recruiting.to_date).getTime() <= Date.now();
+    !recruiting.is_active ||
+    (recruiting.to_date !== undefined &&
+      recruiting.to_date !== null &&
+      new Date(recruiting.to_date).getTime() <= Date.now());
 
   const refetchRecruiting = () =>
     Promise.all([
@@ -113,6 +114,7 @@ export default function Dashboard() {
           confirmLabel="지원 취소하기"
           onConfirm={handleCancel}
           onClose={cancelModal.closeModal}
+          irreversible
         />
       </Modal>
       <Main>
@@ -188,7 +190,7 @@ export default function Dashboard() {
                 </SubmitButton>
               )}
               {errorMessage && (
-                <ErrorText role="status">{errorMessage}</ErrorText>
+                <ErrorText role="alert">{errorMessage}</ErrorText>
               )}
             </ActionArea>
           </>

--- a/src/pages/Loader/DashboardLoader.ts
+++ b/src/pages/Loader/DashboardLoader.ts
@@ -2,6 +2,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { getRecruitingById } from "../../apis/recruiting/recruiting.api";
 import { Recruiting } from "../../apis/recruiting/recruiting.types";
 import { getMyResumes } from "../../apis/resume/resume.api";
+import { Resume } from "../../apis/resume/resume.types";
 import { redirect } from "react-router-dom";
 import { checkAuth } from "../../apis/auth/auth.api";
 
@@ -19,7 +20,7 @@ export const myResumeQuery = (id: number) => ({
 
 export type DashboardLoaderReturnType = {
   recruiting: Recruiting & { applied?: boolean };
-  resume: { items: unknown[] };
+  resume: { items: Resume[] };
 };
 
 export const dashboardLoader =
@@ -71,7 +72,7 @@ export const dashboardLoader =
 
     let resume;
     try {
-      resume = await queryClient.fetchQuery<{ items: unknown[] }>(
+      resume = await queryClient.fetchQuery<{ items: Resume[] }>(
         myResumeQuery(id),
       );
     } catch {

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,14 +1,25 @@
-import { useLoaderData, useNavigate } from "react-router-dom";
+import { useLoaderData, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
+import { useQuery } from "@tanstack/react-query";
 import Header from "../components/home/Header/Header";
 import { ResultLoaderReturnType } from "./Loader/ResultLoader";
+import { recruitingDetailQuery } from "./Loader/DashboardLoader";
 import { useEffect } from "react";
-import { MAIL_RECRUIT } from "../common/const";
+import { MAIL_RECRUIT, ORIENTATION_DATE } from "../common/const";
 import { generateMailUrl } from "../common/utils";
 import { RecruitingResultCode } from "../apis/recruiting/recruiting.types";
 
 export default function Result() {
   const { result } = useLoaderData() as ResultLoaderReturnType;
+  const params = useParams();
+  const recruitId = Number(params.recruit_id);
+  const { data: recruiting } = useQuery({
+    ...recruitingDetailQuery(recruitId),
+    enabled: !Number.isNaN(recruitId),
+    retry: 0,
+  });
+  const recruitingName = recruiting?.name ?? "이번 리크루팅";
+
   if (result.status === RecruitingResultCode.REJECTED) {
     //불합격 시
     return (
@@ -23,7 +34,7 @@ export default function Result() {
             <Description>
               와플스튜디오 리크루팅에 참여해 주셔서 감사드립니다.
               <br />
-              지원서를 검토한 결과, 아쉽게도 23.5기 루키/디자이너 합격자 명단에
+              지원서를 검토한 결과, 아쉽게도 {recruitingName} 합격자 명단에
               포함되지 않았음을 알려드립니다.
               <br />
               지원해 주신 노력에 진심으로 감사드리며, 미래에 더 나은 기회가
@@ -54,9 +65,10 @@ export default function Result() {
               와플스튜디오 <Emphasis>합격</Emphasis>을 축하드립니다!
             </Title>
             <Description>
-              지원 시 적어주셨던 이메일로 슬랙 초대 예정입니다. <br />
-              또한 2025년 8월 31일 (일요일) 에 루키/디자이너 오리엔테이션이
-              진행될 예정이니 참고 바랍니다. 오티 참석은 필수입니다.
+              지원 시 적어주셨던 이메일로 디스코드 초대 예정입니다. <br />
+              또한 {ORIENTATION_DATE}에 루키/디자이너 오리엔테이션이 진행될
+              예정이니 참고 바랍니다. <br />
+              오티 참석은 필수입니다.
             </Description>
             <Contact>
               기타 문의사항은{" "}

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -66,9 +66,10 @@ export default function Result() {
             </Title>
             <Description>
               지원 시 적어주셨던 이메일로 디스코드 초대 예정입니다. <br />
-              또한 {ORIENTATION_DATE}에 루키/디자이너 오리엔테이션이 진행될
+              또한 {ORIENTATION_DATE}에 루키/디자이너 OT 및 개강 파티가 진행될
               예정이니 참고 바랍니다. <br />
-              오티 참석은 필수입니다.
+              OT 참석은 필수이며, 부득이하게 참석이 어려운 경우 디스코드로
+              운영팀에 문의해주세요.
             </Description>
             <Contact>
               기타 문의사항은{" "}

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -5,11 +5,16 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import UserInfoForm from "../components/rookie/UserInfoForm/UserInfoForm.tsx";
 import { putResume } from "../apis/resume/resume.api";
-import { useLoaderData, useNavigate, useParams } from "react-router-dom";
+import { useLoaderData, useParams } from "react-router-dom";
 import { ResumeSubmissionCreate } from "../apis/resume/resume.types";
 import { UserInvitationEmails, UserUpdate } from "../apis/user/user.types";
 import { ResumeLoaderReturnType } from "./Loader/ResumeLoader.ts";
 import { patchUser, patchUserInvitationEmails } from "../apis/user/user.api";
+import Modal from "../components/Modal/Modal.tsx";
+import AlertModal from "../components/Modal/AlertModal.tsx";
+import useModals from "../components/Modal/useModals.tsx";
+
+type Alert = { title: string; description?: string; afterClose?: () => void };
 
 export default function Resume() {
   const { recruit_id } = useParams<{ recruit_id: string }>();
@@ -18,11 +23,26 @@ export default function Resume() {
   const [userInfoInput, setUserInfoInput] = useState(initialData.userInputs);
 
   const putResume = useSubmit(Number(recruit_id));
-  const navigate = useNavigate();
+
+  const [alertModal] = useModals(1);
+  const [alertContent, setAlertContent] = useState<Alert | null>(null);
+
+  const openAlert = (content: Alert) => {
+    setAlertContent(content);
+    alertModal.openModal();
+  };
+
+  const closeAlert = () => {
+    alertModal.closeModal();
+    alertContent?.afterClose?.();
+  };
 
   const submit = (options?: Parameters<typeof putResume>[1]) => {
     if (!checkRequired(userInfoInput)) {
-      alert("필수 정보를 모두 입력하세요");
+      openAlert({
+        title: "필수 정보를 모두 입력해주세요.",
+        description: "추가 정보 입력의 모든 항목은 필수 응답 항목입니다.",
+      });
       return;
     }
 
@@ -56,6 +76,19 @@ export default function Resume() {
   return (
     <>
       <Header />
+      <Modal
+        handle={alertModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+        onBackgroundClicked={closeAlert}
+      >
+        {alertContent && (
+          <AlertModal
+            title={alertContent.title}
+            description={alertContent.description}
+            onClose={closeAlert}
+          />
+        )}
+      </Modal>
       <Main>
         <Title>자기소개서</Title>
         <Description>모든 문항에 성실히 응답해주세요.</Description>
@@ -94,28 +127,20 @@ export default function Resume() {
           ref={userInfoFormRef}
         />
         <Buttons>
-          <SaveButton
-            onClick={() => {
-              submit({
-                onSuccess: () => alert("저장되었습니다."),
-                onError: () => alert("모집이 마감되었습니다."),
-              });
-            }}
-          >
-            임시저장
-          </SaveButton>
           <SubmitButton
             onClick={() =>
               submit({
-                onSuccess: () => {
-                  alert("제출되었습니다.");
-                  navigate(`/recruiting/${recruit_id}`);
-                },
-                onError: () => alert("모집이 마감되었습니다."),
+                onSuccess: () =>
+                  openAlert({
+                    title: "저장되었습니다.",
+                    description:
+                      "마감 전까지 언제든 이어서 작성할 수 있습니다.",
+                  }),
+                onError: () => openAlert({ title: "모집이 마감되었습니다." }),
               })
             }
           >
-            제출하기
+            저장하기
           </SubmitButton>
         </Buttons>
       </Main>
@@ -166,18 +191,6 @@ const checkRequired = (
   return true;
 };
 
-// const pickValidInputOnly = (
-//   userInfo: UserUpdate & UserInvitationEmails,
-// ): Partial<UserUpdate & UserInvitationEmails> => {
-//   const validInput: Partial<UserUpdate & UserInvitationEmails> = {};
-//   for (const key in userInfo) {
-//     if (userInfo[key as keyof (UserUpdate & UserInvitationEmails)] !== "")
-//       validInput[key as keyof (UserUpdate & UserInvitationEmails)] =
-//         userInfo[key as keyof (UserUpdate & UserInvitationEmails)];
-//   }
-//   return validInput;
-// };
-
 const Main = styled.main`
   position: relative;
   font-family: Pretendard, sans-serif;
@@ -217,24 +230,6 @@ const Buttons = styled.div`
   justify-content: flex-end;
   gap: 2.5rem;
 `;
-const SaveButton = styled.button`
-  display: inline-flex;
-  padding: 1rem 2rem;
-  justify-content: center;
-  align-items: flex-start;
-  border-radius: 0.5rem;
-  border: none;
-  background: #f0f0f0;
-  color: #737373;
-  font-size: 2rem;
-  font-weight: 500;
-  cursor: pointer;
-
-  transition: background 0.2s ease-in-out;
-  &:hover {
-    background: #e6e6e6;
-  }
-`;
 const SubmitButton = styled.button`
   display: inline-flex;
   padding: 1rem 2rem;
@@ -250,7 +245,6 @@ const SubmitButton = styled.button`
 
   transition: background 0.2s ease-in-out;
   &:hover {
-    background: #fff;
-    color: #f0745f;
+    background: #e05c46;
   }
 `;

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -13,8 +13,9 @@ import { patchUser, patchUserInvitationEmails } from "../apis/user/user.api";
 import Modal from "../components/Modal/Modal.tsx";
 import AlertModal from "../components/Modal/AlertModal.tsx";
 import useModals from "../components/Modal/useModals.tsx";
+import { resolveApiErrorMessage } from "../lib/apiErrorMessage.ts";
 
-type Alert = { title: string; description?: string; afterClose?: () => void };
+type Alert = { title: string; description?: string };
 
 export default function Resume() {
   const { recruit_id } = useParams<{ recruit_id: string }>();
@@ -34,7 +35,6 @@ export default function Resume() {
 
   const closeAlert = () => {
     alertModal.closeModal();
-    alertContent?.afterClose?.();
   };
 
   const submit = (options?: Parameters<typeof putResume>[1]) => {
@@ -136,7 +136,11 @@ export default function Resume() {
                     description:
                       "마감 전까지 언제든 이어서 작성할 수 있습니다.",
                   }),
-                onError: () => openAlert({ title: "모집이 마감되었습니다." }),
+                onError: (error) =>
+                  void resolveApiErrorMessage(
+                    error,
+                    "저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
+                  ).then((message) => openAlert({ title: message })),
               })
             }
           >

--- a/src/pages/SolveV2.tsx
+++ b/src/pages/SolveV2.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { flushSync } from "react-dom";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import {
   getProblemById,
@@ -18,7 +18,13 @@ import {
 import DragResizable from "../components/solve/DragResizable.tsx";
 import ProblemDescription from "../components/solve/ProblemDescription/ProblemDescription.tsx";
 import { useCustomTestCases } from "../components/solve/ProblemDescription/useCustomTestCases.tsx";
+import ProblemTabs from "../components/solve/ProblemTabs.tsx";
 import TestResultConsole from "../components/solve/TestResultConsoleV2.tsx";
+import Modal from "../components/Modal/Modal.tsx";
+import ConfirmModal from "../components/Modal/ConfirmModal.tsx";
+import useModals from "../components/Modal/useModals.tsx";
+import { recruitingDetailQuery } from "./Loader/DashboardLoader.ts";
+import { resolveApiErrorMessage } from "../lib/apiErrorMessage.ts";
 import { unreachable } from "../lib/unreachable.ts";
 import { ProblemSubmissionResultV2 } from "../apis/problem/problem.types";
 
@@ -26,6 +32,7 @@ export default function Solve() {
   const params = useParams();
   const queryClient = useQueryClient();
   const problemNumber = Number(params.problem_number);
+  const recruitId = Number(params.recruit_id);
   const {
     data: problem,
     isLoading,
@@ -36,9 +43,13 @@ export default function Solve() {
     staleTime: 1000 * 60 * 60,
     retry: 1,
   });
+  const { data: recruiting } = useQuery({
+    ...recruitingDetailQuery(recruitId),
+    enabled: !Number.isNaN(recruitId),
+    retry: 0,
+  });
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [language, setLanguage] = useLanguage();
-  // const [code, setCode] = useCode(language, problemNumber);
   const [isCodeInitialized, setIsCodeInitialized] = useState(true);
   const codeRef = useCodeRef(language, problemNumber);
   const [customTestcases, setCustomTestcases] =
@@ -49,83 +60,102 @@ export default function Solve() {
     [],
   );
   const [submitError, setSubmitError] = useState<string[]>([]);
+  const [actionError, setActionError] = useState<string | null>(null);
   const testConsoleRef = useRef<HTMLUListElement>(null);
+  const [resetModal] = useModals(1);
+
+  const problemTabs = [...(recruiting?.problem_status ?? [])].sort(
+    (a, b) => a.num - b.num,
+  );
 
   const handleSubmit = async (is_example: boolean) => {
     if (!codeRef.current) {
-      alert("코드를 입력해주세요");
+      setActionError("코드를 입력해주세요.");
       return;
     }
 
+    setActionError(null);
     setIsSubmitting(true);
     queryClient.invalidateQueries(["recruiting"]);
     setTestResults([]);
     setSubmitError([]);
-    const res = postProblemSubmissionV2({
-      problem_id: problemNumber,
-      language: languageCodesV2[language],
-      source_code: codeRef.current,
-      is_example,
-      extra_testcases: is_example
-        ? customTestcases.map((t) => ({
-            stdin: t.input,
-            expected_output: t.output,
-          }))
-        : [],
-    }).catch((e: Response) => {
-      return e.json().then((data: { detail?: string }) => {
-        if (data.detail) throw Error(data.detail);
-        else {
-          throw Error("코드 제출에 실패했습니다. 운영팀에게 문의해주세요.");
-        }
+
+    try {
+      await postProblemSubmissionV2({
+        problem_id: problemNumber,
+        language: languageCodesV2[language],
+        source_code: codeRef.current,
+        is_example,
+        extra_testcases: is_example
+          ? customTestcases.map((t) => ({
+              stdin: t.input,
+              expected_output: t.output,
+            }))
+          : [],
       });
-    });
-    res
-      .then(() => getProblemSubmissionV2(problemNumber))
-      .then(async (res) => {
-        for await (const { data, type } of res) {
-          switch (type) {
-            case "skip":
-              break;
-            case "message":
-              flushSync(() => {
-                setTestResults((prev) => [...prev, ...data.items]);
+    } catch (e) {
+      setActionError(
+        await resolveApiErrorMessage(
+          e,
+          "코드 제출에 실패했습니다. 운영팀에게 문의해주세요.",
+        ),
+      );
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      for await (const { data, type } of getProblemSubmissionV2(
+        problemNumber,
+      )) {
+        switch (type) {
+          case "skip":
+            break;
+          case "message":
+            flushSync(() => {
+              setTestResults((prev) => [...prev, ...data.items]);
+            });
+            if (testConsoleRef.current) {
+              testConsoleRef.current.lastElementChild?.scrollIntoView({
+                behavior: "smooth",
               });
-              if (testConsoleRef.current) {
-                testConsoleRef.current.lastElementChild?.scrollIntoView({
-                  behavior: "smooth",
-                });
-              }
-              break;
-            case "error":
-              console.log(data);
-              flushSync(() => {
-                setSubmitError((prev) => [...prev, data.detail]);
+            }
+            break;
+          case "error":
+            flushSync(() => {
+              setSubmitError((prev) => [...prev, data.detail]);
+            });
+            if (testConsoleRef.current) {
+              testConsoleRef.current.lastElementChild?.scrollIntoView({
+                behavior: "smooth",
               });
-              if (testConsoleRef.current) {
-                testConsoleRef.current.lastElementChild?.scrollIntoView({
-                  behavior: "smooth",
-                });
-              }
-              break;
-            case "unknown":
-              console.error(`Unknown data: ${data}`);
-              break;
-            default:
-              unreachable(type);
-          }
+            }
+            break;
+          case "unknown":
+            console.error(`Unknown data: ${data}`);
+            break;
+          default:
+            unreachable(type);
         }
-      })
-      .catch((e) => {
-        if (e instanceof Error) {
-          alert(e.message);
-        } else {
-          alert("채점 결과 조회에 실패했습니다. 운영팀에게 문의 바랍니다.");
-        }
-      })
-      .finally(() => {
-        setIsSubmitting(false);
-      });
+      }
+    } catch (e) {
+      setActionError(
+        await resolveApiErrorMessage(
+          e,
+          "채점 결과 조회에 실패했습니다. 운영팀에게 문의 바랍니다.",
+        ),
+      );
+    } finally {
+      setIsSubmitting(false);
+      queryClient.invalidateQueries(["recruiting"]);
+    }
+  };
+
+  const handleResetCode = () => {
+    resetModal.closeModal();
+    codeRef.current = boilerplates[language];
+    setIsCodeInitialized(true);
+    setActionError(null);
   };
 
   /**
@@ -142,13 +172,25 @@ export default function Solve() {
 
   return (
     <Container>
+      <Modal
+        handle={resetModal}
+        modalContainerBackgroundColor="rgba(0, 0, 0, 0.6)"
+      >
+        <ConfirmModal
+          title="코드를 초기화할까요?"
+          description="작성한 코드가 모두 지워지고 기본 코드로 되돌아갑니다."
+          confirmLabel="초기화하기"
+          onConfirm={handleResetCode}
+          onClose={resetModal.closeModal}
+        />
+      </Modal>
       <Main>
-        <TopNav>
-          <Link to={`/recruiting/${params.recruit_id}`}>
-            <img src="/icon/LeftArrow.svg" alt="&larr;" width={31} />
-            Back
-          </Link>
-        </TopNav>
+        <ProblemTabs
+          recruitId={recruitId}
+          problems={problemTabs}
+          currentProblemId={problemNumber}
+          judgingProblemId={isSubmitting ? problemNumber : undefined}
+        />
         <Row $collapseLeft={isFullScreen}>
           <Col>
             <ProblemDescription
@@ -185,31 +227,37 @@ export default function Solve() {
               </DragResizable>
             </Col>
             <BottomNav>
-              <SubmitButton
-                onClick={() => handleSubmit(false)}
-                disabled={isSubmitting}
-                $primary
-              >
-                제출하기
-              </SubmitButton>
-              {/* <SubmitButton
+              <NoticeArea>
+                {actionError ? (
+                  <ErrorText role="status">{actionError}</ErrorText>
+                ) : (
+                  <NoticeText>
+                    메인 리크루팅 페이지에서 <em>최종 제출하기</em> 버튼을
+                    눌러야 지원이 완료됩니다.
+                  </NoticeText>
+                )}
+              </NoticeArea>
+              <Buttons>
+                <SubmitButton
+                  onClick={() => handleSubmit(false)}
+                  disabled={isSubmitting}
+                  $primary
+                >
+                  {isSubmitting ? "채점 중..." : "제출하기"}
+                </SubmitButton>
+                {/* <SubmitButton
                 onClick={() => handleSubmit(true)}
                 disabled={isSubmitting}
               >
                 테스트 실행
               </SubmitButton> */}
-              <SubmitButton
-                onClick={() => {
-                  if (!confirm("정말로 코드를 초기화하시겠습니까?")) {
-                    return;
-                  }
-                  codeRef.current = boilerplates[language];
-                  setIsCodeInitialized(true);
-                }}
-                disabled={isCodeInitialized}
-              >
-                코드 초기화
-              </SubmitButton>
+                <SubmitButton
+                  onClick={resetModal.openModal}
+                  disabled={isCodeInitialized}
+                >
+                  코드 초기화
+                </SubmitButton>
+              </Buttons>
             </BottomNav>
           </Col>
         </Row>
@@ -224,33 +272,31 @@ const Container = styled.div`
   padding: 3rem;
   box-sizing: border-box;
   background: #fff7e9;
+
+  @media (max-width: 1200px) {
+    padding: 2rem;
+  }
+
+  @media (max-width: 768px) {
+    height: auto;
+    min-height: 100vh;
+    padding: 1.2rem;
+  }
 `;
 const Main = styled.main`
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   border: 0.4rem solid #373737;
   box-shadow: 1rem 1rem #373737;
   border-radius: 0.5rem;
   background: white;
-`;
-const TopNav = styled.nav`
-  display: flex;
-  align-items: center;
-  padding: 1.4rem;
-  background: #f0745f;
-  border-bottom: 0.4rem solid #373737;
 
-  a {
-    display: flex;
-    align-items: center;
-    gap: 0.8rem;
-    font-weight: bold;
-    font-size: 1.6rem;
-    color: #000000;
-    text-decoration: none;
+  @media (max-width: 768px) {
+    box-shadow: 0.5rem 0.5rem #373737;
   }
 `;
 const Row = styled.div<{ $collapseLeft?: boolean }>`
@@ -267,6 +313,18 @@ const Row = styled.div<{ $collapseLeft?: boolean }>`
       opacity: 0;`}
     transition: ease 0.3s;
   }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 1.6rem;
+    padding: 0 1rem 1rem;
+
+    & > :first-child {
+      flex: none;
+      max-height: 50vh;
+      opacity: 1;
+    }
+  }
 `;
 const Col = styled.div`
   display: flex;
@@ -279,8 +337,39 @@ const BottomNav = styled.nav`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 1.6rem;
+  flex-wrap: wrap;
+  gap: 1.2rem 1.6rem;
   padding: 1.6rem 0 0;
+`;
+const NoticeArea = styled.div`
+  flex: 1 1 20rem;
+  min-width: 0;
+  text-align: right;
+`;
+const NoticeText = styled.p`
+  margin: 0;
+  color: #737373;
+  font-size: 1.4rem;
+  line-height: 150%;
+
+  em {
+    font-style: normal;
+    font-weight: 700;
+    color: #373737;
+  }
+`;
+const ErrorText = styled.p`
+  margin: 0;
+  color: #c7382a;
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 150%;
+  white-space: pre-line;
+`;
+const Buttons = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
 `;
 const SubmitButton = styled.button<{ $primary?: boolean }>`
   padding: 0.9rem 2rem;

--- a/src/pages/SolveV2.tsx
+++ b/src/pages/SolveV2.tsx
@@ -229,7 +229,7 @@ export default function Solve() {
             <BottomNav>
               <NoticeArea>
                 {actionError ? (
-                  <ErrorText role="status">{actionError}</ErrorText>
+                  <ErrorText role="alert">{actionError}</ErrorText>
                 ) : (
                   <NoticeText>
                     메인 리크루팅 페이지에서 <em>최종 제출하기</em> 버튼을

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,6 +4443,14 @@ mdast-util-mdxjs-esm@^2.0.0:
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
 
+mdast-util-newline-to-break@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz#4e73ef621b6b1a590240336cfe6c29915e198df0"
+  integrity sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-find-and-replace "^3.0.0"
+
 mdast-util-phrasing@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz#7cc0a8dec30eaf04b7b1a9661a92adb3382aa6e3"
@@ -5379,6 +5387,15 @@ rehype-raw@^7.0.0:
     "@types/hast" "^3.0.0"
     hast-util-raw "^9.0.0"
     vfile "^6.0.0"
+
+remark-breaks@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-4.0.0.tgz#dcc19a2891733906f3b97eaa8acb8621e8da8852"
+  integrity sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-newline-to-break "^2.0.0"
+    unified "^11.0.0"
 
 remark-gfm@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
## 요약

리크루팅 지원 화면(대시보드·자기소개서·문제 풀이·결과)의 UI/UX를 개선하고, 그 과정에서 발견한 버그를 함께 수정했습니다.

## 변경 내역

- 메인 리크루팅 대시보드
  - 지원하기 버튼: '최종 제출하기'로 변경하고 카드 목록 아래로 이동, 크기 키움  → 이젠못누르는일이없겠지
  - 마감 여부와 지원 여주에 따라 4가지 상태로 분기
    - 마감 전 · 미지원 → 최종 제출하기
    - 마감 전 · 지원완료 → 최종 제출 완료(비활성) + 지원 취소
    - 마감 후 · 지원완료 → 지원 결과 확인하기
    - 마감 후 · 미지원 → "지원이 마감되었습니다." 안내
  - 지원 취소가 이상한 위치에 있었던 문제 수정. 버튼으로 변경
  - applied 데이터 소스 통일
  - 최종 제출 시 확인 모달 추가
  - 안 쓰는 주석 제거 및 반응형 추가
- 문제 풀이 창
  - 상단바에 문제 간 이동 탭 추가. 채점 상태(미제출/채점 중/정답/오답)를 점 색으로 표시. 
  - 제출 중인 문제는 서버 응답과 무관하게 즉시 채점 중으로 표시하고, 채점 종료 후 결과를 재조회
  - 제출하기 옆에 "지원 페이지에서 최종 제출하기 버튼을 눌러야 지원이 완료됩니다" 안내 추가. → 이젠지원하기안누르는일이없겠지
  - 콘솔 내 오류를 빨간색으로 구분, 긴 메시지 줄바꿈 처리, 반응형 추가
- 자기소개서
  - 임시저장·제출하기를 저장하기 하나로 통합. 
  - 카드 문구 변경: 제출 완료 → 저장 완료, 미제출 → 작성 전
- 결과
  - 불합격 화면의 기수를 하드코딩(23.5기 루키/디자이너)에서 recruiting.name으로 대체. 
  - 오리엔테이션 일정을 ORIENTATION_DATE 상수로 분리 (src/common/const.ts)
  - 슬랙 → 디스코드 표기 변경 (자기소개서 입력 라벨, 합격 안내, 프로그래머스 안내)
- 공통
  - 브라우저 기본 alert()·confirm()을 ConfirmModal·AlertModal로 교체. 기존 Modal 컴포넌트를 그대로 활용했습니다
  - resolveApiErrorMessage 추가 - 서버 오류 메시지 추출 + 네트워크 장애 분기. 
  - 카드를 <li onClick>에서 <Link>로 변경해 키보드(Tab)로 접근 가능하게 수정. 라벨 없는 빈 버튼도 장식 요소로 정리
  - 리크루팅 페이지 헤더 개선
- 버그 수정
  - 포트폴리오 링크 입력이 즉시 지워지던 문제 - 의존성 버그 개선
  - 마크다운 굵게·기울임이 적용되지 않던 문제 - styled-reset이 strong·em에 font: inherit을 적용해 무력화하는 문제
  - CSS 값에 따옴표가 포함되어 무시되던 스타일 — background: "#fff" 형태로 작성되어 자기소개서·포트폴리오 카드의 hover가 동작하지 않았던 문제
  - 파일 선택 후 input 값을 초기화하지 않아 같은 파일을 연속 선택하면 무시되던 문제

## 체크리스트

- [ ] pre-commit 통과
- [ ] PR Assignees 추가
- [ ] PR Labels 추가

## 기타 질문 및 공유 사항 (Optional)
